### PR TITLE
Check if input is being created correctly.

### DIFF
--- a/Pod/Classes/WPMediaCaptureCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCaptureCollectionViewCell.m
@@ -77,7 +77,12 @@
             
             NSError *error = nil;
             AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
-            [self.session addInput:input];
+            if (input) {
+                [self.session addInput:input];
+            } else {
+                NSLog(@"Error: %@", error);
+                return;
+            }
         }
         if (!self.session.isRunning){
             [self.session startRunning];


### PR DESCRIPTION
Closes #49 