### PR TITLE
Add cache manager for ALAsset

### DIFF
--- a/Pod/Classes/WPALAssetDataSource.m
+++ b/Pod/Classes/WPALAssetDataSource.m
@@ -1,4 +1,5 @@
 #import "WPALAssetDataSource.h"
+#import "WPALAssetImageCacheManager.h"
 
 @interface WPALAssetDataSource  ()
 
@@ -323,27 +324,15 @@
 
 - (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler;
 {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        CGImageRef thumbnailImageRef = [self thumbnail];
-        UIImage *result = [UIImage imageWithCGImage:thumbnailImageRef];
-        if (result.size.width < size.width && result.size.height < size.height) {
-            result = [UIImage imageWithCGImage:[self.defaultRepresentation fullResolutionImage]];
-        }
-        if (completionHandler){
-            if (result) {
-                completionHandler(result, nil);
-            } else {
-                completionHandler(nil, nil);
-            }
-        }
-    });
-    
-    return (WPMediaRequestID)self;
+    CGFloat scale = [[UIScreen mainScreen] scale];
+    return (WPMediaRequestID)[[WPALAssetImageCacheManager sharedInstance] requestImageForAsset:self
+                                                                  targetSize:size
+                                                                       scale:scale resultHandler:completionHandler];
 }
 
 - (void)cancelImageRequest:(WPMediaRequestID)requestID
 {
-    //This implementation doens't actually makes work async so nothing to cancel here.
+    [[WPALAssetImageCacheManager sharedInstance] cancelImageRequest:requestID];
 }
 
 - (WPMediaType)assetType
@@ -423,4 +412,3 @@
 }
 
 @end
-

--- a/Pod/Classes/WPALAssetImageCacheManager.h
+++ b/Pod/Classes/WPALAssetImageCacheManager.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+@import AssetsLibrary;
+
+@interface WPALAssetImageCacheManager : NSObject
+
++ (instancetype)sharedInstance;
+
+- (NSUInteger)requestImageForAsset:(ALAsset *)asset
+                        targetSize:(CGSize)targetSize
+                             scale:(CGFloat)scale
+                     resultHandler:(void (^)(UIImage *result, NSError *error))resultHandler;
+
+- (void)cancelImageRequest:(NSUInteger)requestID;
+
+@end

--- a/Pod/Classes/WPALAssetImageCacheManager.m
+++ b/Pod/Classes/WPALAssetImageCacheManager.m
@@ -1,0 +1,157 @@
+#import "WPALAssetImageCacheManager.h"
+#import "WPMediaCollectionDataSource.h"
+
+@import AVFoundation;
+@import ImageIO;
+
+#pragma mark - WPAssetResizeOperation
+
+@interface WPAssetResizeOperation : NSOperation
+
+- (instancetype)initWithAsset:(ALAsset *)asset
+                   targetSize:(CGSize)targetSize
+                        scale:(CGFloat)scale
+              completionBlock:(WPMediaImageBlock)completionBlock;
+
+@property (nonatomic, strong) ALAsset *asset;
+@property (nonatomic, assign) CGSize targetSize;
+@property (nonatomic, assign) CGFloat scale;
+@property (nonatomic, copy) WPMediaImageBlock block;
+
+@end
+
+@implementation WPAssetResizeOperation
+
+- (instancetype)initWithAsset:(ALAsset *)asset
+                   targetSize:(CGSize)targetSize
+                        scale:(CGFloat)scale
+              completionBlock:(WPMediaImageBlock)completionBlock
+{
+    self = [super init];
+    if (self) {
+        _asset = asset;
+        _targetSize = targetSize;
+        _scale = scale;
+        _block = [completionBlock copy];
+    }
+    return self;
+}
+
+- (void)main
+{
+    CGSize realSize = CGSizeApplyAffineTransform(self.targetSize, CGAffineTransformMakeScale(self.scale, self.scale));
+    UIImage *result;
+    if ([self.asset valueForProperty:ALAssetPropertyType] == ALAssetTypePhoto){
+        result = [self resizedImageWithSize:realSize];
+    } else {
+        result = [UIImage imageWithCGImage:self.asset.thumbnail];
+    }
+    if (self.block){
+        if (result) {
+            self.block(result, nil);
+        } else {
+            self.block(nil, nil);
+        }
+    }
+}
+
+-(UIImage *)resizedImageWithSize:(CGSize)targetSize {
+    ALAssetRepresentation *representation = [self.asset defaultRepresentation];
+    uint8_t *buffer = malloc(representation.size);
+    if ([representation getBytes:buffer fromOffset:0 length:representation.size error:nil] == 0){
+        free(buffer);
+        return nil;
+    }
+    NSData *data = [NSData dataWithBytesNoCopy:buffer length:representation.size];
+    CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    
+    NSDictionary *resizeOptions = @{
+                                    (id)kCGImageSourceCreateThumbnailWithTransform : @YES,
+                                    (id)kCGImageSourceCreateThumbnailFromImageAlways : @YES,
+                                    (id)kCGImageSourceThumbnailMaxPixelSize : @(MAX(targetSize.width, targetSize.height)),
+                                    };
+    
+    CGImageRef resizedImageRef = CGImageSourceCreateThumbnailAtIndex(sourceRef, 0, (__bridge CFDictionaryRef)resizeOptions);
+    UIImage *resizedImage = [UIImage imageWithCGImage:resizedImageRef scale:self.scale orientation:UIImageOrientationUp];
+    CGImageRelease(resizedImageRef);
+    CFRelease(sourceRef);
+    return resizedImage;
+}
+
+@end
+
+@interface WPALAssetImageCacheManager()
+
+@property (nonatomic, strong) NSOperationQueue *operationQueue;
+@property (nonatomic, strong) NSCache *cache;
+@property (nonatomic, strong) NSMutableDictionary *runningOperations;
+
+@end
+
+@implementation WPALAssetImageCacheManager
+
++ (instancetype)sharedInstance {
+    static id _sharedInstance = nil;
+    static dispatch_once_t _onceToken;
+    dispatch_once(&_onceToken, ^{
+        _sharedInstance = [[self alloc] init];
+    });
+    
+    return _sharedInstance;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _operationQueue = [[NSOperationQueue alloc] init];
+        //_operationQueue.maxConcurrentOperationCount = 1;
+        _cache = [[NSCache alloc] init];
+        _runningOperations = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (NSUInteger)requestImageForAsset:(ALAsset *)asset
+                        targetSize:(CGSize)targetSize
+                             scale:(CGFloat)scale
+                     resultHandler:(void (^)(UIImage *result, NSError *error))resultHandler
+{
+    NSString *identifier = [[asset valueForProperty:ALAssetPropertyAssetURL] absoluteString];
+    UIImage *result = [self.cache objectForKey:identifier];
+    if (result) {
+        if (resultHandler) {
+            resultHandler(result, nil);
+        }
+        return 0;
+    }
+    NSNumber *operationKey = @(arc4random());
+    while (self.runningOperations[operationKey] != nil) {
+        operationKey = @(arc4random());
+    }
+    WPAssetResizeOperation *resizeOperation = [[WPAssetResizeOperation alloc] initWithAsset:asset
+                                                                                 targetSize:targetSize
+                                                                                      scale:scale
+                                                                            completionBlock:^(UIImage *result, NSError *error) {
+                                                                                if (result) {
+                                                                                    [self.cache setObject:result forKey:identifier];
+                                                                                }
+                                                                                if (resultHandler) {
+                                                                                    resultHandler(result, error);
+                                                                                }
+                                                                            }];
+    self.runningOperations[operationKey] = resizeOperation;
+    [resizeOperation setCompletionBlock:^{
+        [self.runningOperations removeObjectForKey:operationKey];
+    }];
+    [self.operationQueue addOperation:resizeOperation];
+    
+    return [operationKey unsignedIntegerValue];
+}
+
+- (void)cancelImageRequest:(NSUInteger)requestID
+{
+    [self.runningOperations[@(requestID)] cancel];
+}
+
+@end

--- a/Pod/Classes/WPALAssetImageCacheManager.m
+++ b/Pod/Classes/WPALAssetImageCacheManager.m
@@ -57,12 +57,13 @@
 
 -(UIImage *)resizedImageWithSize:(CGSize)targetSize {
     ALAssetRepresentation *representation = [self.asset defaultRepresentation];
-    uint8_t *buffer = malloc(representation.size);
-    if ([representation getBytes:buffer fromOffset:0 length:representation.size error:nil] == 0){
+    size_t bufferSize = (size_t)representation.size;
+    uint8_t *buffer = malloc(bufferSize);
+    if ([representation getBytes:buffer fromOffset:0 length:bufferSize error:nil] == 0){
         free(buffer);
         return nil;
     }
-    NSData *data = [NSData dataWithBytesNoCopy:buffer length:representation.size];
+    NSData *data = [NSData dataWithBytesNoCopy:buffer length:bufferSize];
     CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
     
     NSDictionary *resizeOptions = @{

--- a/Pod/Classes/WPALAssetImageCacheManager.m
+++ b/Pod/Classes/WPALAssetImageCacheManager.m
@@ -105,7 +105,7 @@
     self = [super init];
     if (self) {
         _operationQueue = [[NSOperationQueue alloc] init];
-        //_operationQueue.maxConcurrentOperationCount = 1;
+        _operationQueue.maxConcurrentOperationCount = 1;
         _cache = [[NSCache alloc] init];
         _runningOperations = [NSMutableDictionary dictionary];
     }
@@ -151,7 +151,10 @@
 
 - (void)cancelImageRequest:(NSUInteger)requestID
 {
-    [self.runningOperations[@(requestID)] cancel];
+    NSOperation *operation =  (NSOperation *)self.runningOperations[@(requestID)];
+    if (operation) {
+        [operation cancel];
+    }
 }
 
 @end


### PR DESCRIPTION
Added a manager to resize images and  cache results for ALAssets.

This avoid that resize operations overflow the system and keeps memory footprint low.

How to test:
 * On a real device, preferably with a lot of photos on the camera roll.
 * Open the example project
 * Click on the + button
 * Scroll trough the list
 * Check the memory footprint of the app to see if memory goes up in big spikes.

Needs Reviews: @sendhil 