### PR TITLE
Add accessibility to Media collection view

### DIFF
--- a/Pod/Classes/WPMediaCaptureCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCaptureCollectionViewCell.m
@@ -107,4 +107,14 @@
     }
 }
 
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+- (NSString *)accessibilityLabel
+{
+    return NSLocalizedString(@"Camera", @"Accessibility label for the camera tile in the collection view");
+}
+
 @end

--- a/Pod/Classes/WPMediaCollectionViewCell.h
+++ b/Pod/Classes/WPMediaCollectionViewCell.h
@@ -7,6 +7,6 @@
 
 - (void)setCaption:(NSString *)caption;
 
-- (void)setImage:(UIImage *)image animated:(BOOL)animated;
+- (void)setImage:(UIImage *)image animated:(BOOL)animated withAccessibilityLabel:(NSString*)accessibilityLabel;
 
 @end

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -40,6 +40,7 @@
 - (void)commonInit
 {
     _imageView = [[UIImageView alloc] init];
+    _imageView.isAccessibilityElement = YES;
     _imageView.contentMode = UIViewContentModeScaleAspectFill;
     _imageView.clipsToBounds = YES;
     _imageView.backgroundColor = self.backgroundColor;
@@ -70,25 +71,28 @@
     [self.contentView addSubview:_captionLabel];
 }
 
-- (void)setImage:(UIImage *)image
+- (void)setImage:(UIImage *)image withAccessibilityLabel:(NSString*)accessibilityLabel
 {
-    [self setImage:image animated:YES];
+    [self setImage:image animated:YES withAccessibilityLabel:accessibilityLabel];
 }
 
-- (void)setImage:(UIImage *)image animated:(BOOL)animated
+- (void)setImage:(UIImage *)image animated:(BOOL)animated withAccessibilityLabel:(NSString*)accessibilityLabel
 {
     if (!image){
         self.imageView.alpha = 0;
         self.imageView.image = nil;
+        self.imageView.accessibilityLabel = nil;
     } else {
         if (animated) {
             [UIView animateWithDuration:0.3 animations:^{
                 self.imageView.alpha = 1.0;
                 self.imageView.image = image;
+                self.imageView.accessibilityLabel = accessibilityLabel;
             }];
         } else {
             self.imageView.alpha = 1.0;
             self.imageView.image = image;
+            self.imageView.accessibilityLabel = accessibilityLabel;
         }
     }
 }


### PR DESCRIPTION
ref [wordpress-mobile/WordPress-iOS#4352](https://github.com/wordpress-mobile/WordPress-iOS/issues/4352) - currently the thumbnails in the media collection view are not accessible. Voice Over won’t be able to get to them because the image views “isAccessibilityElement” property is set to NO. As far as the accessibility label is concerned, the choice made here is to stay simple: just get the index of the asset in the view, and - if available - its type if it’s image or video.

At some point I considered leveraging the caption label for accessibility, but it is actually a deceiving name as it is used only display the duration of video items. Note that since accessibility is now enabled at the UIImageView level in this commit, all the subviews including the caption label will become accessible.