### PR TITLE
Issue/73 fix crash when adding photo

### DIFF
--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -35,6 +35,7 @@
     [self setImage:nil];
     [self setCaption:@""];
     [self setPosition:NSNotFound];
+    [self setSelected:NO];
 }
 
 - (void)commonInit

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -237,6 +237,9 @@ static NSTimeInterval TimeToIgnoreNotificationAfterAddition = 2;
             [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length] - (self.refreshControl.frame.size.height)) animated:YES];
             [self.refreshControl beginRefreshing];
         }
+        // NOTE: Sergio Estevao (2015-11-19)
+        // Clean all assets and refresh collection view when the group was changed
+        // This avoid to see data from previous group while the new one is loading.
         [self.collectionView reloadData];
     }
     self.collectionView.allowsSelection = NO;

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -661,7 +661,7 @@ static NSTimeInterval TimeToIgnoreNotificationAfterAddition = 2;
     self.ignoreMediaTimestamp = [NSDate timeIntervalSinceReferenceDate];
     WPMediaAddedBlock completionBlock = ^(id<WPMediaAsset> media, NSError *error) {
         if (error || !media) {
-            NSLog(@"%@", error);
+            NSLog(@"Adding media failed: %@", [error localizedDescription]);
             return;
         }
         NSInteger mediaItemsAfter = [self.dataSource numberOfAssets];


### PR DESCRIPTION
Closes #73 

This fix avoids animate and crash the app on specific cases where changes events arrive before the animation is done.