### PR TITLE
Remove deprecated rotation methods.

### DIFF
--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -111,23 +111,6 @@ static NSTimeInterval TimeToIgnoreNotificationAfterAddition = 2;
 
 }
 
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
-{
-    self.firstVisibleCell = [self.collectionView.indexPathsForVisibleItems firstObject];
-    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-}
-
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
-{
-    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-    if (!self.firstVisibleCell){
-        return;
-    }
-    [self.collectionView scrollToItemAtIndexPath:self.firstVisibleCell
-                                atScrollPosition:UICollectionViewScrollPositionLeft|UICollectionViewScrollPositionTop
-                                        animated:NO];
-}
-
 - (void)viewWillLayoutSubviews {
     [super viewWillLayoutSubviews];
     [self setupLayout];


### PR DESCRIPTION
Remove deprecate rotation methods that where missing from the ios8 upgrade.

The code inside the methods was not relevant anymore because it was trying to compensate some rotations issues with the layout code. This code was changed on the iOS 8 upgrade so this fix is no longer needed.