### PR TITLE
Add extra smart folders to the group picker

### DIFF
--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -89,17 +89,43 @@
     }];
 }
 
+- (NSArray *)smartAlbumsToShow {
+    NSMutableArray *smartAlbumsOrder = [NSMutableArray arrayWithArray:@[
+                                                                        @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+                                                                        @(PHAssetCollectionSubtypeSmartAlbumRecentlyAdded),
+                                                                        @(PHAssetCollectionSubtypeSmartAlbumFavorites),
+                                                                        @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
+                                                                        @(PHAssetCollectionSubtypeSmartAlbumVideos),
+                                                                        @(PHAssetCollectionSubtypeSmartAlbumSlomoVideos),
+                                                                        @(PHAssetCollectionSubtypeSmartAlbumTimelapses),
+                                                                        ]];
+    // Add iOS 9's new albums
+    NSOperatingSystemVersion iOS9 = {9,0,0};
+    if ( [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:iOS9]) {
+        [smartAlbumsOrder insertObject:@(PHAssetCollectionSubtypeSmartAlbumSelfPortraits) atIndex:3];
+        [smartAlbumsOrder addObject:@(PHAssetCollectionSubtypeSmartAlbumScreenshots)];
+    }
+    return [NSArray arrayWithArray:smartAlbumsOrder];
+}
+
 - (void)loadGroupsWithSuccess:(WPMediaChangesBlock)successBlock
                       failure:(WPMediaFailureBlock)failureBlock
 {
-    NSMutableArray * collectionsArray=[NSMutableArray array];
-    PHFetchResult * cameraAlbum = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum
-                                                                           subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary
+    NSMutableArray *collectionsArray=[NSMutableArray array];
+    for (NSNumber *subType in [self smartAlbumsToShow]) {
+        PHFetchResult * smartAlbum = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum
+                                                                           subtype:[subType intValue]
                                                                            options:nil];
+        PHAssetCollection *collection = (PHAssetCollection *)smartAlbum.firstObject;
+        if ([PHAsset fetchAssetsInAssetCollection:collection options:nil].count > 0){
+            [collectionsArray addObjectsFromArray:[smartAlbum objectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, smartAlbum.count)]]];
+        }
+    }
+    
     PHFetchResult * albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
                                                                            subtype:PHAssetCollectionSubtypeAny
                                                                            options:nil];
-    [collectionsArray addObjectsFromArray:[cameraAlbum objectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, cameraAlbum.count)]]];
+
     [collectionsArray addObjectsFromArray:[albums objectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, albums.count)]]];
     
     PHCollectionList *allAlbums = [PHCollectionList transientCollectionListWithCollections:collectionsArray title:@"Root"];

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -365,7 +365,7 @@
 
 - (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler
 {
-    PHAsset *posterAsset = [[PHAsset fetchAssetsInAssetCollection:self options:nil] firstObject];
+    PHAsset *posterAsset = [[PHAsset fetchAssetsInAssetCollection:self options:nil] lastObject];
     return [posterAsset imageWithSize:size completionHandler:completionHandler];
 }
 


### PR DESCRIPTION
Closes #96 
Refs  https://github.com/wordpress-mobile/WordPress-iOS/issues/4741

How to test:
 - On the device
 - Start the picker
 - See if the albums like favourites, videos and panoramas now show in the album picker

