### PR TITLE
Improve changes observing

### DIFF
--- a/Pod/Classes/WPIndexMove.h
+++ b/Pod/Classes/WPIndexMove.h
@@ -1,0 +1,12 @@
+@import Foundation;
+
+#import "WPMediaCollectionDataSource.h"
+
+@interface WPIndexMove : NSObject<WPMediaMove>
+
+@property (nonatomic, assign, readonly) NSUInteger from;
+@property (nonatomic, assign, readonly) NSUInteger to;
+
+- (instancetype)init:(NSUInteger)from to:(NSUInteger)to;
+
+@end

--- a/Pod/Classes/WPIndexMove.m
+++ b/Pod/Classes/WPIndexMove.m
@@ -1,0 +1,21 @@
+#import "WPIndexMove.h"
+
+@interface WPIndexMove()
+
+@property (nonatomic, assign) NSUInteger from;
+@property (nonatomic, assign) NSUInteger to;
+
+@end
+
+@implementation WPIndexMove
+
+- (instancetype)init:(NSUInteger)from to:(NSUInteger)to
+{
+    self = [super init];
+    if (self) {
+        _from = from;
+        _to = to;
+    }
+    return self;
+}
+@end

--- a/Pod/Classes/WPMediaCollectionDataSource.h
+++ b/Pod/Classes/WPMediaCollectionDataSource.h
@@ -261,5 +261,19 @@ typedef int32_t WPMediaRequestID;
  */
 - (WPMediaType)mediaTypeFilter;
 
+/**
+ *  Sets the sorting order the assets are show based on creationDate
+ *
+ *  @param ascending the order wich assets are retrieved, based on the creationDate. The default value is YES
+ */
+- (void)setAscendingOrdering:(BOOL)ascending;
+
+/**
+ *  The sorting order on wich the assets are returned
+ *
+ *  @return if the assets are return in ascending order
+ */
+- (BOOL)ascendingOrdering;
+
 @end
 

--- a/Pod/Classes/WPMediaCollectionDataSource.h
+++ b/Pod/Classes/WPMediaCollectionDataSource.h
@@ -13,9 +13,15 @@ typedef NS_ENUM(NSInteger, WPMediaPickerErrorCode){
     WPMediaErrorCodePermissionsUnknow
 };
 
+@protocol WPMediaMove <NSObject>
+- (NSUInteger)from;
+- (NSUInteger)to;
+@end
+
 @protocol WPMediaAsset;
 
-typedef void (^WPMediaChangesBlock)();
+typedef void (^WPMediaChangesBlock)(BOOL incrementalChanges, NSIndexSet *removed, NSIndexSet *inserted, NSIndexSet *changed, NSArray<id<WPMediaMove>> *moves);
+typedef void (^WPMediaSuccessBlock)();
 typedef void (^WPMediaFailureBlock)(NSError *error);
 typedef void (^WPMediaAddedBlock)(id<WPMediaAsset> media, NSError *error);
 typedef void (^WPMediaImageBlock)(UIImage *result, NSError *error);
@@ -217,7 +223,7 @@ typedef int32_t WPMediaRequestID;
  *  @param successBlock a block that is invoked when the data is loaded with success.
  *  @param failureBlock a block that is invoked when the are is any kind of error when loading the data.
  */
-- (void)loadDataWithSuccess:(WPMediaChangesBlock)successBlock
+- (void)loadDataWithSuccess:(WPMediaSuccessBlock)successBlock
                     failure:(WPMediaFailureBlock)failureBlock;
 
 /**

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -1,6 +1,6 @@
 #import "WPMediaCollectionViewCell.h"
 
-static const NSTimeInterval ThredsholdForAnimation = 0.03;
+static const NSTimeInterval ThresholdForAnimation = 0.03;
 static const CGFloat TimeForFadeAnimation = 0.3;
 
 @interface WPMediaCollectionViewCell ()
@@ -96,7 +96,7 @@ static const CGFloat TimeForFadeAnimation = 0.3;
         if (requestKey != self.tag) {
             return;
         }
-        BOOL animated = ([NSDate timeIntervalSinceReferenceDate] - timestamp) > ThredsholdForAnimation;
+        BOOL animated = ([NSDate timeIntervalSinceReferenceDate] - timestamp) > ThresholdForAnimation;
         if ([NSThread isMainThread]){
             [self setImage:result
                   animated:animated];

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -88,16 +88,15 @@ static const CGFloat TimeForFadeAnimation = 0.3;
     CGSize requestSize = CGSizeApplyAffineTransform(self.frame.size, CGAffineTransformMakeScale(scale, scale));
 
     requestKey = [_asset imageWithSize:requestSize completionHandler:^(UIImage *result, NSError *error) {
-        BOOL animated = ([NSDate timeIntervalSinceReferenceDate] - timestamp) > ThredsholdForAnimation;
         if (error) {
             self.image = nil;
-            NSLog(@"%@", [error localizedDescription]);
             return;
         }
         // Did this request changed meanwhile
         if (requestKey != self.tag) {
             return;
         }
+        BOOL animated = ([NSDate timeIntervalSinceReferenceDate] - timestamp) > ThredsholdForAnimation;
         if ([NSThread isMainThread]){
             [self setImage:result
                   animated:animated];

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -87,6 +87,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
 
     //setup data
     [self.dataSource setMediaTypeFilter:self.filter];
+    [self.dataSource setAscendingOrdering:!self.showMostRecentFirst];
     __weak __typeof__(self) weakSelf = self;
     self.changesObserver = [self.dataSource registerChangeObserverBlock:
                             ^(BOOL incrementalChanges, NSIndexSet *removed, NSIndexSet *inserted, NSIndexSet *changed, NSArray *moves) {
@@ -334,9 +335,6 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
 {
     NSInteger itemPosition = indexPath.item;
     NSInteger count = [self.dataSource numberOfAssets];
-    if (self.showMostRecentFirst){
-        itemPosition = count - 1 - itemPosition;
-    }
     if (itemPosition >= count || itemPosition < 0) {
         return nil;
     }

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -207,16 +207,20 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
         if (inserted) {
             [self.collectionView insertItemsAtIndexPaths:[self indexPathsFromIndexSet:inserted section:0]];
         }
-        if (changed) {
-            [self.collectionView reloadItemsAtIndexPaths:[self indexPathsFromIndexSet:changed section:0]];
-        }
-        for (id<WPMediaMove> move in moves) {
-            [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:[move from] inSection:0]
-                                         toIndexPath:[NSIndexPath indexPathForItem:[move to] inSection:0]];
-        }
     } completion:^(BOOL finished) {
-        [self refreshSelection];
+        [self.collectionView performBatchUpdates:^{
+            if (changed) {
+                [self.collectionView reloadItemsAtIndexPaths:[self indexPathsFromIndexSet:changed section:0]];
+            }
+            for (id<WPMediaMove> move in moves) {
+                [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:[move from] inSection:0]
+                                             toIndexPath:[NSIndexPath indexPathForItem:[move to] inSection:0]];
+            }
+        } completion:^(BOOL finished) {
+            [self refreshSelection];
+        }];
     }];
+
 }
 
 -(NSArray *)indexPathsFromIndexSet:(NSIndexSet *)indexSet section:(NSInteger)section{

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -218,6 +218,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
             }
         } completion:^(BOOL finished) {
             [self refreshSelection];
+            [self.collectionView reloadItemsAtIndexPaths:self.collectionView.indexPathsForSelectedItems];
         }];
     }];
 

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -219,7 +219,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
 }
 
 -(NSArray *)indexPathsFromIndexSet:(NSIndexSet *)indexSet section:(NSInteger)section{
-    NSMutableArray *indexPaths = [NSMutableArray array];
+    NSMutableArray *indexPaths = [NSMutableArray arrayWithCapacity:indexSet.count];
     [indexSet enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
         [indexPaths addObject:[NSIndexPath indexPathForItem:idx inSection:section]];
     }];

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -290,12 +290,17 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     if (error.domain == WPMediaPickerErrorDomain &&
         error.code == WPMediaErrorCodePermissionsFailed) {
         otherButtonTitle = NSLocalizedString(@"Open Settings", @"Go to the settings app");
+        title = NSLocalizedString(@"Media Library", @"Title for alert when access to the media library is not granted by the user");
+        message = NSLocalizedString(@"This app needs permission to access your device media library in order to add photos and/or video to your posts. Please change the privacy settings if you wish to allow this.",
+                                    @"Explaining to the user why the app needs access to the device media library.");
     }
-    title = NSLocalizedString(@"Media Library", @"Title for alert when access to the media library is not granted by the user");
-    message = NSLocalizedString(@"This app needs permission to access your device media library in order to add photos and/or video to your posts. Please change the privacy settings if you wish to allow this.",  @"Explaining to the user why the app needs access to the device media library.");
     
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-    UIAlertAction *okAction = [UIAlertAction actionWithTitle:cancelText style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
+                                                                             message:message
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:cancelText
+                                                       style:UIAlertActionStyleCancel
+                                                     handler:^(UIAlertAction *action) {
         if ([self.picker.delegate respondsToSelector:@selector(mediaPickerControllerDidCancel:)]) {
             [self.picker.delegate mediaPickerControllerDidCancel:self.picker];
         }

--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -42,9 +42,9 @@ static CGFloat const WPMediaGroupCellHeight = 50.0f;
     //Setup navigation
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
     __weak __typeof__(self) weakSelf = self;
-    self.changesObserver = [self.dataSource registerChangeObserverBlock:^{
-        [weakSelf loadData];
-    }];
+    self.changesObserver = [self.dataSource registerChangeObserverBlock:^(BOOL incrementalChanges, NSIndexSet *deleted, NSIndexSet *inserted, NSIndexSet *reload, NSArray *moves) {
+            [weakSelf loadData];
+        }];
     [self loadData];
 }
 

--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -79,7 +79,6 @@ static CGFloat const WPMediaGroupCellHeight = 50.0f;
                               completionHandler:^(UIImage *result, NSError *error)
     {
         if (error) {
-            NSLog(@"%@", [error localizedDescription]);
             return;
         }
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/Pod/Classes/WPMediaPicker.h
+++ b/Pod/Classes/WPMediaPicker.h
@@ -5,5 +5,8 @@
 #import "WPMediaCollectionDataSource.h"
 #import "WPMediaCollectionViewCell.h"
 #import "WPPHAssetDataSource.h"
+#import "WPMediaCapturePreviewCollectionView.h"
+#import "WPMediaGroupPickerViewController.h"
+#import "WPIndexMove.h"
 
 #endif /* _WPMEDIAPICKER_ */

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -39,6 +39,7 @@
     static dispatch_once_t _onceToken;
     dispatch_once(&_onceToken, ^{
         _sharedImageManager = [[PHCachingImageManager alloc] init];
+        [_sharedImageManager setAllowsCachingHighQualityImages:NO];
     });
     
     return _sharedImageManager;

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -34,7 +34,7 @@
     [[PHPhotoLibrary sharedPhotoLibrary] unregisterChangeObserver:self];
 }
 
-+ (PHImageManager *) sharedImageManager
++ (PHCachingImageManager *) sharedImageManager
 {
     static PHCachingImageManager *_sharedImageManager = nil;
     static dispatch_once_t _onceToken;
@@ -90,6 +90,7 @@
             return;
         }
         if (self.refreshGroups) {
+            [[[self class] sharedImageManager] stopCachingImagesForAllAssets];
             [self loadGroupsWithSuccess:^{
                 self.refreshGroups = NO;
                 [self loadAssetsWithSuccess:successBlock failure:failureBlock];

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -314,8 +314,8 @@
 {
     PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
     options.synchronous = NO;
-    options.deliveryMode = PHImageRequestOptionsDeliveryModeOpportunistic;
-    options.resizeMode = PHImageRequestOptionsResizeModeFast;
+    options.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
+    options.resizeMode = PHImageRequestOptionsResizeModeExact;
     options.networkAccessAllowed = YES;
     return [[WPPHAssetDataSource sharedImageManager] requestImageForAsset:self
                                                         targetSize:size
@@ -324,7 +324,7 @@
                                                      resultHandler:^(UIImage *result, NSDictionary *info) {
          NSError *error = info[PHImageErrorKey];
          NSNumber *canceled = info[PHImageCancelledKey];
-         if (error){
+         if (error || canceled){
              if (completionHandler && ![canceled boolValue]){
                  completionHandler(nil, error);
              }

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -319,8 +319,9 @@
                                                            options:options
                                                      resultHandler:^(UIImage *result, NSDictionary *info) {
          NSError *error = info[PHImageErrorKey];
+         NSNumber *canceled = info[PHImageCancelledKey];
          if (error){
-             if (completionHandler){
+             if (completionHandler && ![canceled boolValue]){
                  completionHandler(nil, error);
              }
              return;

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -10,6 +10,7 @@
 @property (nonatomic, assign) WPMediaType mediaTypeFilter;
 @property (nonatomic, strong) NSMutableDictionary *observers;
 @property (nonatomic, assign) BOOL refreshGroups;
+@property (nonatomic, assign) BOOL ascendingOrdering;
 
 @end
 
@@ -176,6 +177,7 @@
             
             break;
     }
+    fetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.ascendingOrdering]];
     self.assets = [PHAsset fetchAssetsInAssetCollection:self.activeAssetsCollection options:fetchOptions];
     if (successBlock) {
         successBlock();

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -314,6 +314,7 @@
     PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
     options.synchronous = NO;
     options.deliveryMode = PHImageRequestOptionsDeliveryModeOpportunistic;
+    options.resizeMode = PHImageRequestOptionsResizeModeFast;
     options.networkAccessAllowed = YES;
     return [[WPPHAssetDataSource sharedImageManager] requestImageForAsset:self
                                                         targetSize:size

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -36,7 +36,7 @@
 
 + (PHImageManager *) sharedImageManager
 {
-    static id _sharedImageManager = nil;
+    static PHCachingImageManager *_sharedImageManager = nil;
     static dispatch_once_t _onceToken;
     dispatch_once(&_onceToken, ^{
         _sharedImageManager = [[PHCachingImageManager alloc] init];


### PR DESCRIPTION
This PR changes the interface for the data source observers to allow reporting of incremental changes.

== How to test ==

To test this properly several scenarios must be run:

 - Add images and videos inside the picker and see if all updates correctly
 - Switch to the Photos app and remove some images and see if it updates correctly when switching back
 - Add some photos using the camera app and then switch back to see if they show
 - Using a iCloud folder test if removal and insertions done remotely (using the iCloud web interface) are done correctly. 
 - Scroll in a big iCloud library and check if no flickering occurs.

Needs Review: @frosty 
