### PR TITLE
Add option to use front camera for capture

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -129,6 +129,7 @@
     mediaPicker.delegate = self;
     mediaPicker.showMostRecentFirst = [self.options[MediaPickerOptionsShowMostRecentFirst] boolValue];
     mediaPicker.allowCaptureOfMedia = [self.options[MediaPickerOptionsShowCameraCapture] boolValue];
+    mediaPicker.preferFrontCamera = [self.options[MediaPickerOptionsPreferFrontCamera] boolValue];
     mediaPicker.allowMultipleSelection = [self.options[MediaPickerOptionsAllowMultipleSelection] boolValue];
     mediaPicker.modalPresentationStyle = UIModalPresentationPopover;
     UIPopoverPresentationController *ppc = mediaPicker.popoverPresentationController;

--- a/Example/WPMediaPicker/OptionsViewController.h
+++ b/Example/WPMediaPicker/OptionsViewController.h
@@ -2,6 +2,7 @@
 
 extern NSString const *MediaPickerOptionsShowMostRecentFirst;
 extern NSString const *MediaPickerOptionsShowCameraCapture;
+extern NSString const *MediaPickerOptionsPreferFrontCamera;
 extern NSString const *MediaPickerOptionsAllowMultipleSelection;
 extern NSString const *MediaPickerOptionsPostProcessingStep;
 

--- a/Example/WPMediaPicker/OptionsViewController.m
+++ b/Example/WPMediaPicker/OptionsViewController.m
@@ -3,12 +3,14 @@
 NSString const *MediaPickerOptionsShowMostRecentFirst = @"MediaPickerOptionsShowMostRecentFirst";
 NSString const *MediaPickerOptionsUsePhotosLibrary = @"MediaPickerOptionsUsePhotosLibrary";
 NSString const *MediaPickerOptionsShowCameraCapture = @"MediaPickerOptionsShowCameraCapture";
+NSString const *MediaPickerOptionsPreferFrontCamera = @"MediaPickerOptionsPreferFrontCamera";
 NSString const *MediaPickerOptionsAllowMultipleSelection = @"MediaPickerOptionsAllowMultipleSelection";
 NSString const *MediaPickerOptionsPostProcessingStep = @"MediaPickerOptionsPostProcessingStep";
 
 typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellShowMostRecentFirst,
     OptionsViewControllerCellShowCameraCapture,
+    OptionsViewControllerCellPreferFrontCamera,
     OptionsViewControllerCellAllowMultipleSelection,
     OptionsViewControllerCellPostProcessingStep,
     OptionsViewControllerCellTotal
@@ -18,6 +20,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
 
 @property (nonatomic, strong) UITableViewCell *showMostRecentFirstCell;
 @property (nonatomic, strong) UITableViewCell *showCameraCaptureCell;
+@property (nonatomic, strong) UITableViewCell *preferFrontCameraCell;
 @property (nonatomic, strong) UITableViewCell *allowMultipleSelectionCell;
 @property (nonatomic, strong) UITableViewCell *postProcessingStepCell;
 
@@ -43,6 +46,10 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     self.showCameraCaptureCell.accessoryView = [[UISwitch alloc] init];
     ((UISwitch *)self.showCameraCaptureCell.accessoryView).on = [self.options[MediaPickerOptionsShowCameraCapture] boolValue];
     self.showCameraCaptureCell.textLabel.text = @"Show Capture Cell";
+
+    self.preferFrontCameraCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    self.preferFrontCameraCell.accessoryView = [[UISwitch alloc] init];
+    self.preferFrontCameraCell.textLabel.text = @"Prefer Front Camera";
     
     self.allowMultipleSelectionCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
     self.allowMultipleSelectionCell.accessoryView = [[UISwitch alloc] init];
@@ -76,6 +83,9 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
         case OptionsViewControllerCellShowCameraCapture:
             return self.showCameraCaptureCell;
             break;
+        case OptionsViewControllerCellPreferFrontCamera:
+            return self.preferFrontCameraCell;
+            break;
         case OptionsViewControllerCellAllowMultipleSelection:
             return self.allowMultipleSelectionCell;
             break;
@@ -95,6 +105,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
         NSDictionary *newOptions = @{
              MediaPickerOptionsShowMostRecentFirst:@(((UISwitch *)self.showMostRecentFirstCell.accessoryView).on),
              MediaPickerOptionsShowCameraCapture:@(((UISwitch *)self.showCameraCaptureCell.accessoryView).on),
+             MediaPickerOptionsPreferFrontCamera:@(((UISwitch *)self.preferFrontCameraCell.accessoryView).on),
              MediaPickerOptionsAllowMultipleSelection:@(((UISwitch *)self.allowMultipleSelectionCell.accessoryView).on),
              MediaPickerOptionsPostProcessingStep:@(((UISwitch *)self.postProcessingStepCell.accessoryView).on)
              };

--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.h
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.h
@@ -2,6 +2,8 @@
 
 @interface WPMediaCapturePreviewCollectionView : UICollectionReusableView
 
+@property (nonatomic, assign) BOOL preferFrontCamera;
+
 - (void)stopCaptureOnCompletion:(void (^)(void))block;
 - (void)startCapture;
 

--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -80,8 +80,7 @@
             self.session = [[AVCaptureSession alloc] init];
             self.session.sessionPreset = AVCaptureSessionPreset1280x720;
             
-            AVCaptureDevice *device =
-            [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+            AVCaptureDevice *device = [self captureDevice];
             
             NSError *error = nil;
             AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
@@ -121,6 +120,18 @@
 - (NSString *)accessibilityLabel
 {
     return NSLocalizedString(@"Camera", @"Accessibility label for the camera tile in the collection view");
+}
+
+- (AVCaptureDevice *)captureDevice
+{
+    if (self.preferFrontCamera) {
+        for (AVCaptureDevice *device in [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo]) {
+            if (device.position == AVCaptureDevicePositionFront) {
+                return device;
+            }
+        }
+    }
+    return [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
 }
 
 @end

--- a/Pod/Classes/WPMediaCollectionViewController.h
+++ b/Pod/Classes/WPMediaCollectionViewController.h
@@ -9,6 +9,11 @@
 @property (nonatomic, assign) BOOL allowCaptureOfMedia;
 
 /**
+ If the media picker allows media capturing, it will use the front camera by default when possible
+ */
+@property (nonatomic, assign) BOOL preferFrontCamera;
+
+/**
  If set the picker will show the most recent items on the top left. If not set it will show on the bottom right. Either way it will always scroll to the most recent item when showing the picker.
  */
 @property (nonatomic, assign) BOOL showMostRecentFirst;

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -41,6 +41,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
         _layout = layout;
         _selectedAssets = [[NSMutableArray alloc] init];
         _allowCaptureOfMedia = YES;
+        _preferFrontCamera = NO;
         _showMostRecentFirst = NO;
         _filter = WPMediaTypeVideoOrImage;
         _refreshGroupFirstTime = YES;
@@ -413,6 +414,7 @@ referenceSizeForFooterInSection:(NSInteger)section
             UIGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showCapture)];
             [self.captureCell addGestureRecognizer:tapGestureRecognizer];
         }
+        self.captureCell.preferFrontCamera = self.preferFrontCamera;
         [self.captureCell startCapture];
         return self.captureCell;
     }
@@ -571,10 +573,20 @@ referenceSizeForFooterInSection:(NSInteger)section
     imagePickerController.mediaTypes = [mediaTypes allObjects];
     imagePickerController.delegate = self;
     imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+    imagePickerController.cameraDevice = [self cameraDevice];
     imagePickerController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     [self presentViewController:imagePickerController animated:YES completion:^{
 
     }];
+}
+
+- (UIImagePickerControllerCameraDevice)cameraDevice
+{
+    if (self.preferFrontCamera && [UIImagePickerController isCameraDeviceAvailable:UIImagePickerControllerCameraDeviceFront]) {
+        return UIImagePickerControllerCameraDeviceFront;
+    } else {
+        return UIImagePickerControllerCameraDeviceRear;
+    }
 }
 
 - (void)captureMedia

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -21,6 +21,11 @@
 @property (nonatomic, assign) BOOL allowCaptureOfMedia;
 
 /**
+ If the media picker allows media capturing, it will use the front camera by default when possible
+ */
+@property (nonatomic, assign) BOOL preferFrontCamera;
+
+/**
  If set the picker will allow the selection of multiple items. By default this value is YES.
  */
 @property (nonatomic, assign) BOOL allowMultipleSelection;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -13,6 +13,7 @@
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
         _allowCaptureOfMedia = YES;
+        _preferFrontCamera = NO;
         _showMostRecentFirst = NO;
         _allowMultipleSelection = YES;
         _filter = WPMediaTypeVideoOrImage;
@@ -39,6 +40,7 @@
 {
     WPMediaCollectionViewController *vc = [[WPMediaCollectionViewController alloc] init];
     vc.allowCaptureOfMedia = self.allowCaptureOfMedia;
+    vc.preferFrontCamera = self.preferFrontCamera;
     vc.showMostRecentFirst = self.showMostRecentFirst;
     vc.filter = self.filter;
     vc.allowMultipleSelection = self.allowMultipleSelection;


### PR DESCRIPTION
If the media picker allows media capturing, this adds the option to use the front camera by default when possible.