### PR TITLE
Issue/112 media filters not considered in groups

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -35,7 +35,8 @@
                      MediaPickerOptionsShowMostRecentFirst:@(YES),
                      MediaPickerOptionsShowCameraCapture:@(YES),
                      MediaPickerOptionsAllowMultipleSelection:@(YES),
-                     MediaPickerOptionsPostProcessingStep:@(NO)
+                     MediaPickerOptionsPostProcessingStep:@(NO),
+                     MediaPickerOptionsFilterType:@(WPMediaTypeVideoOrImage)
                      };
 
 }
@@ -131,6 +132,7 @@
     mediaPicker.allowCaptureOfMedia = [self.options[MediaPickerOptionsShowCameraCapture] boolValue];
     mediaPicker.preferFrontCamera = [self.options[MediaPickerOptionsPreferFrontCamera] boolValue];
     mediaPicker.allowMultipleSelection = [self.options[MediaPickerOptionsAllowMultipleSelection] boolValue];
+    mediaPicker.filter = [self.options[MediaPickerOptionsFilterType] intValue];
     mediaPicker.modalPresentationStyle = UIModalPresentationPopover;
     UIPopoverPresentationController *ppc = mediaPicker.popoverPresentationController;
     ppc.barButtonItem = sender;

--- a/Example/WPMediaPicker/OptionsViewController.h
+++ b/Example/WPMediaPicker/OptionsViewController.h
@@ -5,6 +5,7 @@ extern NSString const *MediaPickerOptionsShowCameraCapture;
 extern NSString const *MediaPickerOptionsPreferFrontCamera;
 extern NSString const *MediaPickerOptionsAllowMultipleSelection;
 extern NSString const *MediaPickerOptionsPostProcessingStep;
+extern NSString const *MediaPickerOptionsFilterType;
 
 @class OptionsViewController;
 

--- a/Example/WPMediaPicker/OptionsViewController.m
+++ b/Example/WPMediaPicker/OptionsViewController.m
@@ -6,6 +6,7 @@ NSString const *MediaPickerOptionsShowCameraCapture = @"MediaPickerOptionsShowCa
 NSString const *MediaPickerOptionsPreferFrontCamera = @"MediaPickerOptionsPreferFrontCamera";
 NSString const *MediaPickerOptionsAllowMultipleSelection = @"MediaPickerOptionsAllowMultipleSelection";
 NSString const *MediaPickerOptionsPostProcessingStep = @"MediaPickerOptionsPostProcessingStep";
+NSString const *MediaPickerOptionsFilterType = @"MediaPickerOptionsFilterType";
 
 typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellShowMostRecentFirst,
@@ -13,6 +14,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellPreferFrontCamera,
     OptionsViewControllerCellAllowMultipleSelection,
     OptionsViewControllerCellPostProcessingStep,
+    OptionsViewControllerCellMediaType,
     OptionsViewControllerCellTotal
 };
 
@@ -23,6 +25,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
 @property (nonatomic, strong) UITableViewCell *preferFrontCameraCell;
 @property (nonatomic, strong) UITableViewCell *allowMultipleSelectionCell;
 @property (nonatomic, strong) UITableViewCell *postProcessingStepCell;
+@property (nonatomic, strong) UITableViewCell *filterMediaCell;
 
 @end
 
@@ -60,6 +63,12 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     self.postProcessingStepCell.accessoryView = [[UISwitch alloc] init];
     ((UISwitch *)self.postProcessingStepCell.accessoryView).on = [self.options[MediaPickerOptionsPostProcessingStep] boolValue];
     self.postProcessingStepCell.textLabel.text = @"Shows Post Processing Step";
+
+    self.filterMediaCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    UISegmentedControl *segment = [[UISegmentedControl alloc] initWithItems:@[@"Photos", @"Videos", @"Photos & Videos"]];
+    self.filterMediaCell.accessoryView = segment;
+    segment.selectedSegmentIndex = [self.options[MediaPickerOptionsFilterType] intValue];
+    self.filterMediaCell.textLabel.text = @"Media Type";
 }
 
 #pragma mark - Table view data source
@@ -92,10 +101,13 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
         case OptionsViewControllerCellPostProcessingStep:
             return self.postProcessingStepCell;
             break;
+        case OptionsViewControllerCellMediaType:
+            return self.filterMediaCell;
+            break;
         default:
             break;
     }
-    return nil;
+    return [UITableViewCell new];
 }
 
 - (void)done:(id) sender
@@ -107,7 +119,8 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
              MediaPickerOptionsShowCameraCapture:@(((UISwitch *)self.showCameraCaptureCell.accessoryView).on),
              MediaPickerOptionsPreferFrontCamera:@(((UISwitch *)self.preferFrontCameraCell.accessoryView).on),
              MediaPickerOptionsAllowMultipleSelection:@(((UISwitch *)self.allowMultipleSelectionCell.accessoryView).on),
-             MediaPickerOptionsPostProcessingStep:@(((UISwitch *)self.postProcessingStepCell.accessoryView).on)
+             MediaPickerOptionsPostProcessingStep:@(((UISwitch *)self.postProcessingStepCell.accessoryView).on),
+             MediaPickerOptionsFilterType:@(((UISegmentedControl *)self.filterMediaCell.accessoryView).selectedSegmentIndex),
              };
         
         [delegate optionsViewController:self changed:newOptions];

--- a/Pod/Classes/WPMediaCollectionDataSource.h
+++ b/Pod/Classes/WPMediaCollectionDataSource.h
@@ -68,7 +68,7 @@ typedef int32_t WPMediaRequestID;
  *
  *  @return The numbers of assets that exist in the group
  */
-- (NSInteger)numberOfAssets;
+- (NSInteger)numberOfAssetsOfType:(WPMediaType)mediaType;
 
 @end
 
@@ -250,7 +250,7 @@ typedef int32_t WPMediaRequestID;
 /**
  *  Filter the assets acording to their media type.
  *
- *  @param filter the WMMediaType to filter objects to. The default value is WPMediaTypeAll
+ *  @param filter the WMMediaType to filter objects to. The default value is WPMediaTypeVideoOrImage
  */
 - (void)setMediaTypeFilter:(WPMediaType)filter;
 

--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -89,7 +89,7 @@ static CGFloat const WPMediaGroupCellHeight = 50.0f;
     }];
     cell.tag = requestKey;
     cell.titleLabel.text = [group name];
-    NSInteger numberOfAssets = [group numberOfAssets];
+    NSInteger numberOfAssets = [group numberOfAssetsOfType:[self.dataSource mediaTypeFilter]];
     if (numberOfAssets != NSNotFound) {
         cell.countLabel.text = [NSString stringWithFormat:@"%ld", (long)numberOfAssets];
     } else {


### PR DESCRIPTION
Closes #112 

How to Test:
 - Launch the demo app
 - Go to Options and select Video or Photos
 - Go back to the main screen and select +
 - Check if the groups/collections available on the top, show the correct number of assets for the filter selected.

Needs Review: @frosty 