### PR TITLE
Filter poster image of group

### DIFF
--- a/Pod/Classes/WPPHAssetDataSource.h
+++ b/Pod/Classes/WPPHAssetDataSource.h
@@ -20,6 +20,11 @@ NS_CLASS_AVAILABLE_IOS(8_0) @interface WPPHAssetDataSource : NSObject<WPMediaCol
 /**
  An implementation of the WPMediaGroup protocol using the PHAssetCollection class
  */
-@interface PHAssetCollection(WPMediaGroup)<WPMediaGroup>
+@interface PHAssetCollectionForWPMediaGroup:NSObject <WPMediaGroup>
+
+@property(nonatomic, strong) PHAssetCollection *collection;
+@property(nonatomic, assign) WPMediaType mediaType;
+
+- (instancetype)initWithCollection:(PHAssetCollection *)collection mediaType:(WPMediaType)mediaType;
 
 @end

--- a/Pod/Classes/WPPHAssetDataSource.h
+++ b/Pod/Classes/WPPHAssetDataSource.h
@@ -20,10 +20,7 @@ NS_CLASS_AVAILABLE_IOS(8_0) @interface WPPHAssetDataSource : NSObject<WPMediaCol
 /**
  An implementation of the WPMediaGroup protocol using the PHAssetCollection class
  */
-@interface PHAssetCollectionForWPMediaGroup:NSObject <WPMediaGroup>
-
-@property(nonatomic, strong) PHAssetCollection *collection;
-@property(nonatomic, assign) WPMediaType mediaType;
+@interface PHAssetCollectionForWPMediaGroup : NSObject<WPMediaGroup>
 
 - (instancetype)initWithCollection:(PHAssetCollection *)collection mediaType:(WPMediaType)mediaType;
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -386,6 +386,13 @@
 
 #pragma mark - WPPHAssetCollection
 
+@interface PHAssetCollectionForWPMediaGroup()
+
+@property(nonatomic, strong) PHAssetCollection *collection;
+@property(nonatomic, assign) WPMediaType mediaType;
+
+@end
+
 @implementation PHAssetCollectionForWPMediaGroup
 
 - (instancetype)initWithCollection:(PHAssetCollection *)collection mediaType:(WPMediaType)mediaType


### PR DESCRIPTION
Refs #112 

This PR fix the poster image of a group by filtering it according to the media type selected.

How to test:
 - Launch the demo app
 - Tap on options
 - Select filter by video
 - Tap on the plus
 - Tap on the Group selector on the top
 - Check if the poster images show for each group reflect a video asset in the group.

Needs Review: @frosty 