### PR TITLE
Release session when stopping capture.

### DIFF
--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -61,6 +61,7 @@
     dispatch_async(self.sessionQueue, ^{
         if ([self.session isRunning]){
             [self.session stopRunning];
+            self.session = nil;
         }
         dispatch_async(dispatch_get_main_queue(), block);
     });


### PR DESCRIPTION
Closes #121 

How to test:

 - Start the picker app
 - Tap on the live preview header
 - Capture one photo
 - Accept the photo
 - Check if coming back to the picker no blocking of the UI happens.
 