### PR TITLE
Specifies a less specific session quality to prevent iPhone 4s crash.

### DIFF
--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -79,7 +79,7 @@
 
         if (!self.session){
             self.session = [[AVCaptureSession alloc] init];
-            self.session.sessionPreset = AVCaptureSessionPreset1280x720;
+            self.session.sessionPreset = AVCaptureSessionPresetHigh;
             
             AVCaptureDevice *device = [self captureDevice];
             


### PR DESCRIPTION
Closes #129 

Using this table: http://stackoverflow.com/a/31964333

Setting the session capture quality to `AVCaptureSessionPresetHigh` rather than `AVCaptureSessionPreset1280x720` which isn't supported on the front camera for the iPhone 4s.

@kurzee did verify this fixed the crash.