### PR TITLE
Fix RTL in group picker.

### DIFF
--- a/Pod/Classes/WPMediaGroupTableViewCell.m
+++ b/Pod/Classes/WPMediaGroupTableViewCell.m
@@ -15,31 +15,31 @@ static CGFloat const WPMediaGroupTableViewCellImageMargin = 15.0;
     _imagePosterView = [[UIImageView alloc] initWithFrame:CGRectZero];
     _imagePosterView.contentMode = UIViewContentModeScaleAspectFill;
     _imagePosterView.clipsToBounds = YES;
+    _imagePosterView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.contentView addSubview:_imagePosterView];
     
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _titleLabel.font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
+    _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
     [self.contentView addSubview:_titleLabel];
     
     _countLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _countLabel.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
+    _countLabel.translatesAutoresizingMaskIntoConstraints = NO;
     [self.contentView addSubview:_countLabel];
-    
+
+    [_imagePosterView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:WPMediaGroupTableViewCellImageMargin].active = YES;
+    [_imagePosterView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:WPMediaGroupTableViewCellImagePadding].active = YES;
+    [_imagePosterView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:WPMediaGroupTableViewCellImagePadding].active = YES;
+    [_imagePosterView.widthAnchor constraintEqualToAnchor:_imagePosterView.heightAnchor].active = YES;
+    [_titleLabel.leadingAnchor constraintEqualToAnchor:_imagePosterView.trailingAnchor constant:WPMediaGroupTableViewCellImageMargin].active = YES;
+    [_titleLabel.trailingAnchor constraintEqualToAnchor:self.contentView.layoutMarginsGuide.trailingAnchor].active = YES;
+    [_titleLabel.bottomAnchor constraintEqualToAnchor:self.contentView.centerYAnchor].active = YES;
+    [_countLabel.leadingAnchor constraintEqualToAnchor:_imagePosterView.trailingAnchor constant:WPMediaGroupTableViewCellImageMargin].active = YES;
+    [_countLabel.trailingAnchor constraintEqualToAnchor:self.contentView.layoutMarginsGuide.trailingAnchor].active = YES;
+    [_countLabel.topAnchor constraintEqualToAnchor:self.contentView.centerYAnchor].active = YES;
+
     return self;
-}
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    CGFloat cellHeight = self.contentView.frame.size.height;
-    CGFloat imageHeight = cellHeight-(2*WPMediaGroupTableViewCellImagePadding);
-    self.imagePosterView.frame = CGRectMake(WPMediaGroupTableViewCellImageMargin, WPMediaGroupTableViewCellImagePadding, imageHeight, imageHeight);
-
-    CGFloat titleFontSize = [self.titleLabel.font ascender] - [self.titleLabel.font descender];
-    self.titleLabel.frame = CGRectMake(CGRectGetMaxX(self.imagePosterView.frame) + WPMediaGroupTableViewCellImageMargin, (cellHeight/2)-titleFontSize, self.contentView.frame.size.width-CGRectGetMaxX(self.imageView.frame), titleFontSize);
-    
-    CGFloat countFontSize = [self.countLabel.font ascender] - [self.countLabel.font descender];
-    self.countLabel.frame = CGRectMake(CGRectGetMaxX(self.imagePosterView.frame) + WPMediaGroupTableViewCellImageMargin, cellHeight/2, self.contentView.frame.size.width-CGRectGetMaxX(self.imageView.frame), countFontSize);
 }
 
 @end


### PR DESCRIPTION
Switched to Auto Layout for WPMediaGroupTableViewCell so iOS takes care of
flipping the UI on RTL languages.

For https://github.com/wordpress-mobile/WordPress-iOS/issues/6432

![mp-rtl](https://cloud.githubusercontent.com/assets/8739/22730611/061a5a26-ede8-11e6-89cd-e2d71dfc5586.png)

To test/develop this I had to do it in the WordPress app, as the example project wasn't picking up locale settings. The easiest way to test this is to edit the scheme and switch the language to the RTL Pseudolanguage

![screen shot 2017-02-08 at 10 19 21](https://cloud.githubusercontent.com/assets/8739/22730673/3b2e2ada-ede8-11e6-9b27-87ea9db61976.png)