### PR TITLE
Issue/140 fix crash when editing albums

### DIFF
--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -43,7 +43,9 @@ static CGFloat const WPMediaGroupCellHeight = 50.0f;
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
     __weak __typeof__(self) weakSelf = self;
     self.changesObserver = [self.dataSource registerChangeObserverBlock:^(BOOL incrementalChanges, NSIndexSet *deleted, NSIndexSet *inserted, NSIndexSet *reload, NSArray *moves) {
-            [weakSelf loadData];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [weakSelf loadData];
+            });
         }];
     [self loadData];
 }

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -7,6 +7,7 @@
 @property (nonatomic, strong) PHAssetCollection *activeAssetsCollection;
 @property (nonatomic, strong) PHFetchResult *assetsCollections;
 @property (nonatomic, strong) PHFetchResult *assets;
+@property (nonatomic, strong) PHFetchResult * albums;
 @property (nonatomic, assign) WPMediaType mediaTypeFilter;
 @property (nonatomic, strong) NSMutableDictionary *observers;
 @property (nonatomic, assign) BOOL refreshGroups;
@@ -61,13 +62,14 @@
 {
     PHFetchResultChangeDetails *groupChangeDetails = [changeInstance changeDetailsForFetchResult:self.assetsCollections];
     PHFetchResultChangeDetails *assetsChangeDetails = [changeInstance changeDetailsForFetchResult:self.assets];
-    
-    if (!groupChangeDetails && !assetsChangeDetails) {
+    PHFetchResultChangeDetails *albumChangeDetails = [changeInstance changeDetailsForFetchResult:self.albums];
+
+    if (!groupChangeDetails && !assetsChangeDetails && !albumChangeDetails) {
         return;
     }
     
-    if (groupChangeDetails){
-        self.refreshGroups = YES;
+    if (groupChangeDetails || albumChangeDetails){
+        [self loadGroupsWithSuccess:nil failure:nil];
     }
     BOOL incrementalChanges = assetsChangeDetails.hasIncrementalChanges;
     // Capture removed, changed, and moved indexes before fetching results for incremental chaanges.
@@ -153,11 +155,11 @@
         }
     }
     
-    PHFetchResult * albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
-                                                                           subtype:PHAssetCollectionSubtypeAny
-                                                                           options:nil];
+    self.albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
+                                                           subtype:PHAssetCollectionSubtypeAny
+                                                           options:nil];
 
-    [albums enumerateObjectsUsingBlock:^(PHAssetCollection *collection, NSUInteger index, BOOL *stop){
+    [self.albums enumerateObjectsUsingBlock:^(PHAssetCollection *collection, NSUInteger index, BOOL *stop){
         if ([PHAsset fetchAssetsInAssetCollection:collection options:fetchOptions].count > 0) {
             [collectionsArray addObject:collection];
         }


### PR DESCRIPTION
Fixes #140 

This PR fixes a crash that was happening when album changes where made in the Photos.app when the album picker was open in the MediaPicker.
It also make sure the album list gets updated correctly when changes are made.

How to test:

 - Open the Media Picker demo app and start the picker
 - Tap the group selector on the top
 - While keeping it open, switch to the Photos app
 - Create/Delete/Edit a user album
 - Switch back to the demo app
 - Check if no crash happens and the albums are update accordingly.

