### PR TITLE
Add tip for group change option.

### DIFF
--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -35,7 +35,7 @@
 @implementation WPMediaCollectionViewController
 
 static CGFloat SelectAnimationTime = 0.2;
-static NSString *const ArrowDown = @"\u25bc";
+static NSString *const ArrowDown = @"\u25be";
 static CGSize CameraPreviewSize =  {88.0, 88.0};
 
 - (instancetype)init
@@ -210,15 +210,20 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
         self.titleButton.hidden = NO;
     }
     NSString *localizedOptionHint = NSLocalizedString(@"Tap here to change", "Tip for tapping media picker title to change the group.");
-    NSString *albumName = [NSString stringWithFormat:@"%@\n", [mediaGroup name]];
+    NSString *albumName = NSLocalizedString(@"No Photos", "Group name to show when permission are denied to access Photos albums");
+    if ([mediaGroup name] != nil) {
+        albumName = [mediaGroup name];
+    }
+    NSString *albumLine = [NSString stringWithFormat:@"%@\n", albumName];
     UIFont *titleFont = self.titleButton.titleLabel.font;
-    NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:albumName attributes:@{NSFontAttributeName: titleFont}];
+    NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:albumLine attributes:@{NSFontAttributeName: titleFont}];
     NSString *callForAction = [NSString stringWithFormat:@"%@ %@",localizedOptionHint, ArrowDown];
     [title appendAttributedString:[[NSAttributedString alloc] initWithString:callForAction attributes:@{NSFontAttributeName: [titleFont fontWithSize:floorf(titleFont.pointSize * 0.75)]}]];
 
     [self.titleButton setAttributedTitle:title forState:UIControlStateNormal];
-    self.titleButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    self.titleButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     self.titleButton.titleLabel.textAlignment = NSTextAlignmentCenter;
+    self.titleButton.titleLabel.numberOfLines = 2;
     [self.titleButton sizeToFit];
 }
 

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -221,7 +221,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     [title appendAttributedString:[[NSAttributedString alloc] initWithString:callForAction attributes:@{NSFontAttributeName: [titleFont fontWithSize:floorf(titleFont.pointSize * 0.75)]}]];
 
     [self.titleButton setAttributedTitle:title forState:UIControlStateNormal];
-    self.titleButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+    self.titleButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
     self.titleButton.titleLabel.textAlignment = NSTextAlignmentCenter;
     self.titleButton.titleLabel.numberOfLines = 2;
     [self.titleButton sizeToFit];

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -86,25 +86,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
                    withReuseIdentifier:NSStringFromClass([WPMediaCapturePreviewCollectionView class])];
     [self setupLayout];
 
-    //setup navigation items
-    self.titleButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [self.titleButton addTarget:self action:@selector(changeGroup:) forControlEvents:UIControlEventTouchUpInside];
-
-    self.titleTipButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [self.titleTipButton addTarget:self action:@selector(changeGroup:) forControlEvents:UIControlEventTouchUpInside];
-    self.titleTipButton.backgroundColor = [UIColor clearColor];
-    [self.titleButton addSubview:self.titleTipButton];
-    self.titleTipButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin|UIViewAutoresizingFlexibleRightMargin|UIViewAutoresizingFlexibleWidth;
-    self.titleTipButton.userInteractionEnabled = NO;
-
-    self.navigationItem.titleView = self.titleButton;
-
-
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
-    
-    if (self.allowMultipleSelection) {
-        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(finishPicker:)];
-    }
+    [self setupNavigationItems];
 
     //setup data
     [self.dataSource setMediaTypeFilter:self.filter];
@@ -129,6 +111,54 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     }
 
     [self refreshData];
+}
+
+- (void)setupNavigationItems
+{
+    self.titleButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.titleButton addTarget:self action:@selector(changeGroup:) forControlEvents:UIControlEventTouchUpInside];
+    self.titleButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    self.titleButton.titleLabel.textAlignment = NSTextAlignmentCenter;
+    self.titleButton.titleLabel.numberOfLines = 1;
+
+    self.titleTipButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.titleTipButton addTarget:self action:@selector(changeGroup:) forControlEvents:UIControlEventTouchUpInside];
+    self.titleTipButton.titleLabel.textAlignment = NSTextAlignmentCenter;
+    self.titleTipButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    self.titleTipButton.titleLabel.numberOfLines = 1;
+    NSString *localizedOptionHint = NSLocalizedString(@"Tap here to change", "Tip for tapping media picker title to change the group.");
+    NSString *callForAction = [NSString stringWithFormat:@"%@ %@",localizedOptionHint, ArrowDown];
+    UIFont *titleFont = self.titleButton.titleLabel.font;
+    NSMutableAttributedString *titleTip = [[NSAttributedString alloc] initWithString:callForAction attributes:@{NSFontAttributeName: [titleFont fontWithSize:floorf(titleFont.pointSize * 0.75)]}];
+
+    [self.titleTipButton setAttributedTitle:titleTip forState:UIControlStateNormal];
+
+    UIStackView *stackView = [[UIStackView alloc] initWithArrangedSubviews:@[self.titleButton, self.titleTipButton]];
+    stackView.backgroundColor = [UIColor redColor];
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.alignment = UIStackViewAlignmentCenter;
+    stackView.distribution = UIStackViewDistributionFillProportionally;
+    stackView.spacing = 0;
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UIView *titleView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 200, 40)];
+    titleView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+    [titleView addSubview:stackView];
+
+    [stackView.widthAnchor constraintEqualToAnchor:titleView.widthAnchor multiplier:1].active = YES;
+    [stackView.heightAnchor constraintEqualToAnchor:titleView.heightAnchor multiplier:1].active = YES;
+    [stackView.leftAnchor constraintEqualToAnchor:titleView.leftAnchor].active = YES;
+    [stackView.topAnchor constraintEqualToAnchor:titleView.topAnchor].active = YES;
+
+    self.navigationItem.titleView = titleView;
+
+
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
+
+    if (self.allowMultipleSelection) {
+        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(finishPicker:)];
+    }
+
 }
 
 - (void)setupLayout
@@ -220,7 +250,6 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     } else {
         self.titleButton.hidden = NO;
     }
-    NSString *localizedOptionHint = NSLocalizedString(@"Tap here to change", "Tip for tapping media picker title to change the group.");
     NSString *albumName = NSLocalizedString(@"No Photos", "Group name to show when permission are denied to access Photos albums");
     if ([mediaGroup name] != nil) {
         albumName = [mediaGroup name];
@@ -228,27 +257,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     UIFont *titleFont = self.titleButton.titleLabel.font;
     NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:albumName attributes:@{NSFontAttributeName: titleFont}];
 
-    NSString *callForAction = [NSString stringWithFormat:@"%@ %@",localizedOptionHint, ArrowDown];
-    NSMutableAttributedString *titleTip = [[NSAttributedString alloc] initWithString:callForAction attributes:@{NSFontAttributeName: [titleFont fontWithSize:floorf(titleFont.pointSize * 0.75)]}];
-
-    [self.titleTipButton setAttributedTitle:titleTip forState:UIControlStateNormal];
-    self.titleTipButton.titleLabel.textAlignment = NSTextAlignmentCenter;
-    self.titleTipButton.titleLabel.lineBreakMode = NSLineBreakByClipping;
-    self.titleTipButton.titleLabel.numberOfLines = 1;
-    [self.titleTipButton sizeToFit];
-
     [self.titleButton setAttributedTitle:title forState:UIControlStateNormal];
-    self.titleButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
-    self.titleButton.titleLabel.textAlignment = NSTextAlignmentCenter;
-    self.titleButton.titleLabel.numberOfLines = 1;
-    [self.titleButton sizeToFit];
-
-    CGRect frame = self.titleTipButton.frame;
-
-    frame.origin.x = floorf((self.titleButton.frame.size.width - self.titleTipButton.frame.size.width) / 2.0);
-    frame.origin.y = titleFont.lineHeight;
-    //frame.size.width = MAX(self.titleButton.frame.size.width, self.titleTipButton.frame.size.width);
-    self.titleTipButton.frame = frame;
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -209,7 +209,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     } else {
         self.titleButton.hidden = NO;
     }
-    NSString *localizedOptionHint = NSLocalizedString(@"Tap here to change", "");
+    NSString *localizedOptionHint = NSLocalizedString(@"Tap here to change", "Tip for tapping media picker title to change the group.");
     NSString *albumName = [NSString stringWithFormat:@"%@\n", [mediaGroup name]];
     UIFont *titleFont = self.titleButton.titleLabel.font;
     NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:albumName attributes:@{NSFontAttributeName: titleFont}];

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -35,7 +35,7 @@
 @implementation WPMediaCollectionViewController
 
 static CGFloat SelectAnimationTime = 0.2;
-static NSString *const ArrowDown = @"\u25be";
+static NSString *const ArrowDown = @"\u25bc";
 static CGSize CameraPreviewSize =  {88.0, 88.0};
 
 - (instancetype)init
@@ -209,8 +209,16 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     } else {
         self.titleButton.hidden = NO;
     }
-    NSString *title = [NSString stringWithFormat:@"%@ %@", [mediaGroup name], ArrowDown];
-    [self.titleButton setTitle:title forState:UIControlStateNormal];
+    NSString *localizedOptionHint = NSLocalizedString(@"Tap here to change", "");
+    NSString *albumName = [NSString stringWithFormat:@"%@\n", [mediaGroup name]];
+    UIFont *titleFont = self.titleButton.titleLabel.font;
+    NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:albumName attributes:@{NSFontAttributeName: titleFont}];
+    NSString *callForAction = [NSString stringWithFormat:@"%@ %@",localizedOptionHint, ArrowDown];
+    [title appendAttributedString:[[NSAttributedString alloc] initWithString:callForAction attributes:@{NSFontAttributeName: [titleFont fontWithSize:floorf(titleFont.pointSize * 0.75)]}]];
+
+    [self.titleButton setAttributedTitle:title forState:UIControlStateNormal];
+    self.titleButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    self.titleButton.titleLabel.textAlignment = NSTextAlignmentCenter;
     [self.titleButton sizeToFit];
 }
 

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -23,6 +23,7 @@
 @property (nonatomic, strong) NSMutableArray *selectedAssets;
 @property (nonatomic, strong) WPMediaCapturePreviewCollectionView *captureCell;
 @property (nonatomic, strong) UIButton *titleButton;
+@property (nonatomic, strong) UIButton *titleTipButton;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, strong) NSObject *changesObserver;
 @property (nonatomic, strong) NSIndexPath *firstVisibleCell;
@@ -88,7 +89,17 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     //setup navigation items
     self.titleButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [self.titleButton addTarget:self action:@selector(changeGroup:) forControlEvents:UIControlEventTouchUpInside];
+
+    self.titleTipButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.titleTipButton addTarget:self action:@selector(changeGroup:) forControlEvents:UIControlEventTouchUpInside];
+    self.titleTipButton.backgroundColor = [UIColor clearColor];
+    [self.titleButton addSubview:self.titleTipButton];
+    self.titleTipButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin|UIViewAutoresizingFlexibleRightMargin|UIViewAutoresizingFlexibleWidth;
+    self.titleTipButton.userInteractionEnabled = NO;
+
     self.navigationItem.titleView = self.titleButton;
+
+
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
     
     if (self.allowMultipleSelection) {
@@ -214,17 +225,30 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     if ([mediaGroup name] != nil) {
         albumName = [mediaGroup name];
     }
-    NSString *albumLine = [NSString stringWithFormat:@"%@\n", albumName];
     UIFont *titleFont = self.titleButton.titleLabel.font;
-    NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:albumLine attributes:@{NSFontAttributeName: titleFont}];
+    NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:albumName attributes:@{NSFontAttributeName: titleFont}];
+
     NSString *callForAction = [NSString stringWithFormat:@"%@ %@",localizedOptionHint, ArrowDown];
-    [title appendAttributedString:[[NSAttributedString alloc] initWithString:callForAction attributes:@{NSFontAttributeName: [titleFont fontWithSize:floorf(titleFont.pointSize * 0.75)]}]];
+    NSMutableAttributedString *titleTip = [[NSAttributedString alloc] initWithString:callForAction attributes:@{NSFontAttributeName: [titleFont fontWithSize:floorf(titleFont.pointSize * 0.75)]}];
+
+    [self.titleTipButton setAttributedTitle:titleTip forState:UIControlStateNormal];
+    self.titleTipButton.titleLabel.textAlignment = NSTextAlignmentCenter;
+    self.titleTipButton.titleLabel.lineBreakMode = NSLineBreakByClipping;
+    self.titleTipButton.titleLabel.numberOfLines = 1;
+    [self.titleTipButton sizeToFit];
 
     [self.titleButton setAttributedTitle:title forState:UIControlStateNormal];
     self.titleButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
     self.titleButton.titleLabel.textAlignment = NSTextAlignmentCenter;
-    self.titleButton.titleLabel.numberOfLines = 2;
+    self.titleButton.titleLabel.numberOfLines = 1;
     [self.titleButton sizeToFit];
+
+    CGRect frame = self.titleTipButton.frame;
+
+    frame.origin.x = floorf((self.titleButton.frame.size.width - self.titleTipButton.frame.size.width) / 2.0);
+    frame.origin.y = titleFont.lineHeight;
+    //frame.size.width = MAX(self.titleButton.frame.size.width, self.titleTipButton.frame.size.width);
+    self.titleTipButton.frame = frame;
 }
 
 #pragma mark - UICollectionViewDataSource


### PR DESCRIPTION
This PR add a tip on the group title to indicate that you can change the group

How to test:
 - Start the demo app
 - Start the picker
 - Check the ground title on different orientations, devices and group names to see if it shows correctly.