### PR TITLE
Crash fix: dispatch entire photoLibraryDidChange callback to main queue

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - WPMediaPicker (0.11.2)
+  - WPMediaPicker (0.11.3)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
 
 EXTERNAL SOURCES:
   WPMediaPicker:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 8504d1547b41e5cb024de97d51e2c6b56d8cded7
+  WPMediaPicker: 24a218bcd70cc9620c894129d8bc9d5e1935bd23
 
 PODFILE CHECKSUM: 7855568785f801c5559f8e70856ad87de227dc95
 

--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -101,15 +101,12 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     __weak __typeof__(self) weakSelf = self;
     self.changesObserver = [self.dataSource registerChangeObserverBlock:
                             ^(BOOL incrementalChanges, NSIndexSet *removed, NSIndexSet *inserted, NSIndexSet *changed, NSArray *moves) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (incrementalChanges) {
-                [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
-            } else {
-                [weakSelf refreshData];
-            }
-
-        });
-    }];
+                                if (incrementalChanges) {
+                                    [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
+                                } else {
+                                    [weakSelf refreshData];
+                                }
+                            }];
 
     if ([self.traitCollection containsTraitsInCollection:[UITraitCollection traitCollectionWithForceTouchCapability:UIForceTouchCapabilityAvailable]]) {
         [self registerForPreviewingWithDelegate:self sourceView:self.view];

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "0.11.2"
+  s.version          = "0.11.3"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Fixes #128 

This should resolve another recurring crash for Media.

Looking at the documentation for the `photoLibraryDidChange` used in `WPPHAssetDataSource`, you can see Apple's example of wrapping the entire block to dispatch to the main queue, here:
- https://developer.apple.com/reference/photos/phphotolibrarychangeobserver?language=objc

Without this fix, I suspect there was a case in which the background queue ends up firing `photoLibraryDidChange`, running the changes in that same background queue, but following up with an async UI update that landed out of sync with the model changes. Wrapping the whole block should prevent this. 🤞 

Needs review: @frosty, @SergioEstevao or @astralbodies (we should put this into 7.1 as well)