### PR TITLE
Crash fix: dispatch entire photoLibraryDidChange callback to main queue (only the fix)

### DIFF
--- a/Pod/Classes/WPMediaCollectionViewController.m
+++ b/Pod/Classes/WPMediaCollectionViewController.m
@@ -101,15 +101,12 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     __weak __typeof__(self) weakSelf = self;
     self.changesObserver = [self.dataSource registerChangeObserverBlock:
                             ^(BOOL incrementalChanges, NSIndexSet *removed, NSIndexSet *inserted, NSIndexSet *changed, NSArray *moves) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (incrementalChanges) {
-                [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
-            } else {
-                [weakSelf refreshData];
-            }
-
-        });
-    }];
+                                if (incrementalChanges) {
+                                    [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
+                                } else {
+                                    [weakSelf refreshData];
+                                }
+                            }];
 
     if ([self.traitCollection containsTraitsInCollection:[UITraitCollection traitCollectionWithForceTouchCapability:UIForceTouchCapabilityAvailable]]) {
         [self registerForPreviewingWithDelegate:self sourceView:self.view];


### PR DESCRIPTION
Brings in the commit with the fix from https://github.com/wordpress-mobile/MediaPicker-iOS/pull/143