### PR TITLE
Release 0.11.3

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - WPMediaPicker (0.11.2)
+  - WPMediaPicker (0.11.3)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
 
 EXTERNAL SOURCES:
   WPMediaPicker:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 8504d1547b41e5cb024de97d51e2c6b56d8cded7
+  WPMediaPicker: 24a218bcd70cc9620c894129d8bc9d5e1935bd23
 
 PODFILE CHECKSUM: 7855568785f801c5559f8e70856ad87de227dc95
 

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "0.11.2"
+  s.version          = "0.11.3"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Standalone PR for releasing 0.11.3, originally from https://github.com/wordpress-mobile/MediaPicker-iOS/pull/143.