### PR TITLE
Disable refresh animation on initial load

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -102,7 +102,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
         [self.view addGestureRecognizer:self.longPressGestureRecognizer];
     }
 
-    [self refreshData];
+    [self refreshDataAnimated:NO];
 }
 
 - (void)setupLayout
@@ -183,10 +183,15 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
 
 - (void)refreshData
 {
+    [self refreshDataAnimated:YES];
+}
+
+- (void)refreshDataAnimated:(BOOL)animated
+{
     if (self.refreshGroupFirstTime) {
         if (![self.refreshControl isRefreshing]) {
             [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length]) animated:NO];
-            [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length] - (self.refreshControl.frame.size.height)) animated:YES];
+            [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length] - (self.refreshControl.frame.size.height)) animated:animated];
             [self.refreshControl beginRefreshing];
         }
         // NOTE: Sergio Estevao (2015-11-19)
@@ -208,7 +213,15 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
                 strongSelf.collectionView.allowsMultipleSelection = self.allowMultipleSelection;
                 strongSelf.collectionView.scrollEnabled = YES;
                 [strongSelf.collectionView reloadData];
-                [strongSelf.refreshControl endRefreshing];
+
+                if (animated) {
+                    [strongSelf.refreshControl endRefreshing];
+                } else {
+                    [UIView performWithoutAnimation:^{
+                        [strongSelf.refreshControl endRefreshing];
+                    }];
+                }
+
                 // Scroll to the correct position
                 if (strongSelf.refreshGroupFirstTime && [strongSelf.dataSource numberOfAssets] > 0){
                     NSInteger sectionToScroll = 0;


### PR DESCRIPTION
The animation of `[self.refreshControl endRefreshing]` on the first load of the picker's data results in a vertical 'jump' when first loading the view controller. This looks particularly odd in the new media section, when pushing the collection view onto a navigation stack. This PR disables that animation of the first load.

**Before:**

![media-menu](https://cloud.githubusercontent.com/assets/4780/23622018/e7cad7d2-0294-11e7-86c6-18e5219fcec1.gif)

![add-media-2](https://cloud.githubusercontent.com/assets/4780/23622021/e9b9d002-0294-11e7-9343-98e9f79a9efe.gif)

**After:**

![media-menu-2](https://cloud.githubusercontent.com/assets/4780/23622043/f5cd2ce0-0294-11e7-81a4-aba34fc99b6b.gif)

![add-media-1](https://cloud.githubusercontent.com/assets/4780/23622030/ed5caa90-0294-11e7-81ee-9a49ac64beb1.gif)
