### PR TITLE
Added ability to provide a custom preview view controller

### DIFF
--- a/Example/WPMediaPicker.xcodeproj/project.pbxproj
+++ b/Example/WPMediaPicker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17F64FE01E6DDC74006C5A2B /* CustomPreviewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -39,6 +40,8 @@
 
 /* Begin PBXFileReference section */
 		1120051BDDDC8A558883872E /* Pods-WPMediaPicker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WPMediaPicker.release.xcconfig"; path = "Pods/Target Support Files/Pods-WPMediaPicker/Pods-WPMediaPicker.release.xcconfig"; sourceTree = "<group>"; };
+		17F64FDE1E6DDC74006C5A2B /* CustomPreviewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomPreviewViewController.h; sourceTree = "<group>"; };
+		17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomPreviewViewController.m; sourceTree = "<group>"; };
 		5709B45B57F590232B3E5DA7 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* WPMediaPicker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WPMediaPicker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -140,6 +143,8 @@
 				FFFFD8801A447E67000FC184 /* DemoViewController.m */,
 				B5FF3BE81CAD8AB100C1D597 /* PostProcessingViewController.h */,
 				B5FF3BE91CAD8AB100C1D597 /* PostProcessingViewController.m */,
+				17F64FDE1E6DDC74006C5A2B /* CustomPreviewViewController.h */,
+				17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */,
 				6003F59C195388D20070C39A /* AppDelegate.h */,
 				6003F59D195388D20070C39A /* AppDelegate.m */,
 				6003F5A8195388D20070C39A /* Images.xcassets */,
@@ -403,6 +408,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				17F64FE01E6DDC74006C5A2B /* CustomPreviewViewController.m in Sources */,
 				B5FF3BEA1CAD8AB100C1D597 /* PostProcessingViewController.m in Sources */,
 				6003F59E195388D20070C39A /* AppDelegate.m in Sources */,
 				FFFFD8811A447E67000FC184 /* DemoViewController.m in Sources */,

--- a/Example/WPMediaPicker/CustomPreviewViewController.h
+++ b/Example/WPMediaPicker/CustomPreviewViewController.h
@@ -1,0 +1,11 @@
+@import UIKit;
+
+#import <WPMediaPicker/WPMediaPicker.h>
+
+@interface CustomPreviewViewController : UIViewController
+
+@property (nonatomic, strong) id<WPMediaAsset> asset;
+
+- (instancetype)initWithAsset:(id<WPMediaAsset>)asset;
+
+@end

--- a/Example/WPMediaPicker/CustomPreviewViewController.m
+++ b/Example/WPMediaPicker/CustomPreviewViewController.m
@@ -1,0 +1,68 @@
+#import "CustomPreviewViewController.h"
+
+@interface CustomPreviewViewController ()
+@property (nonatomic, strong) UIImageView *imageView;
+@end
+
+@implementation CustomPreviewViewController
+
+- (instancetype)initWithAsset:(id<WPMediaAsset>)asset
+{
+    if (self = [super initWithNibName:nil bundle:nil]) {
+        _asset = asset;
+    }
+
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    self.title = @"Preview";
+
+    self.view.backgroundColor = [UIColor greenColor];
+
+    [self addImageView];
+    [self loadImage];
+}
+
+- (void)addImageView
+{
+    UIImageView *imageView = [UIImageView new];
+    imageView.contentMode = UIViewContentModeScaleAspectFill;
+    imageView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:imageView];
+
+    [NSLayoutConstraint activateConstraints:@[
+                                              [imageView.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+                                              [imageView.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+                                              [imageView.widthAnchor constraintEqualToConstant:200],
+                                              [imageView.heightAnchor constraintEqualToConstant:200],
+                                              ]];
+
+    self.imageView = imageView;
+}
+
+- (void)loadImage
+{
+    if ([self.asset assetType] == WPMediaTypeImage) {
+        __weak __typeof__(self) weakSelf = self;
+        [self.asset imageWithSize:CGSizeMake(200, 200) completionHandler:^(UIImage *result, NSError *error) {
+            __typeof__(self) strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                strongSelf.imageView.image = result;
+            });
+        }];
+    }
+}
+
+- (CGSize)preferredContentSize
+{
+    return CGSizeMake(200, 200);
+}
+
+@end

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -1,10 +1,12 @@
 #import "DemoViewController.h"
+#import "CustomPreviewViewController.h"
 #import "WPPHAssetDataSource.h"
 #import "OptionsViewController.h"
 #import "PostProcessingViewController.h"
 #import <WPMediaPicker/WPMediaPicker.h>
 #import <WPMediaPicker/WPMediaGroupTableViewCell.h>
 #import <WPMediaPicker/WPMediaPicker.h>
+
 @interface DemoViewController () <WPMediaPickerViewControllerDelegate, OptionsViewControllerDelegate>
 
 @property (nonatomic, strong) NSArray * assets;
@@ -37,7 +39,8 @@
                      MediaPickerOptionsShowCameraCapture:@(YES),
                      MediaPickerOptionsAllowMultipleSelection:@(YES),
                      MediaPickerOptionsPostProcessingStep:@(NO),
-                     MediaPickerOptionsFilterType:@(WPMediaTypeVideoOrImage)
+                     MediaPickerOptionsFilterType:@(WPMediaTypeVideoOrImage),
+                     MediaPickerOptionsCustomPreview:@(NO)
                      };
 
 }
@@ -115,6 +118,15 @@
     };
     
     [self.mediaPicker showAfterViewController:postProcessingViewController];
+}
+
+- (UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAsset:(id<WPMediaAsset>)asset
+{
+    if ([self.options[MediaPickerOptionsCustomPreview] boolValue] == false) {
+        return nil;
+    }
+
+    return [[CustomPreviewViewController alloc] initWithAsset:asset];
 }
 
 #pragma - Actions

--- a/Example/WPMediaPicker/OptionsViewController.h
+++ b/Example/WPMediaPicker/OptionsViewController.h
@@ -6,6 +6,7 @@ extern NSString const *MediaPickerOptionsPreferFrontCamera;
 extern NSString const *MediaPickerOptionsAllowMultipleSelection;
 extern NSString const *MediaPickerOptionsPostProcessingStep;
 extern NSString const *MediaPickerOptionsFilterType;
+extern NSString const *MediaPickerOptionsCustomPreview;
 
 @class OptionsViewController;
 

--- a/Example/WPMediaPicker/OptionsViewController.m
+++ b/Example/WPMediaPicker/OptionsViewController.m
@@ -7,6 +7,7 @@ NSString const *MediaPickerOptionsPreferFrontCamera = @"MediaPickerOptionsPrefer
 NSString const *MediaPickerOptionsAllowMultipleSelection = @"MediaPickerOptionsAllowMultipleSelection";
 NSString const *MediaPickerOptionsPostProcessingStep = @"MediaPickerOptionsPostProcessingStep";
 NSString const *MediaPickerOptionsFilterType = @"MediaPickerOptionsFilterType";
+NSString const *MediaPickerOptionsCustomPreview = @"MediaPickerOptionsCustomPreview";
 
 typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellShowMostRecentFirst,
@@ -15,6 +16,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellAllowMultipleSelection,
     OptionsViewControllerCellPostProcessingStep,
     OptionsViewControllerCellMediaType,
+    OptionsViewControllerCellCustomPreview,
     OptionsViewControllerCellTotal
 };
 
@@ -26,6 +28,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
 @property (nonatomic, strong) UITableViewCell *allowMultipleSelectionCell;
 @property (nonatomic, strong) UITableViewCell *postProcessingStepCell;
 @property (nonatomic, strong) UITableViewCell *filterMediaCell;
+@property (nonatomic, strong) UITableViewCell *customPreviewCell;
 
 @end
 
@@ -70,6 +73,11 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     self.filterMediaCell.accessoryView = segment;
     segment.selectedSegmentIndex = [self.options[MediaPickerOptionsFilterType] intValue];
     self.filterMediaCell.textLabel.text = @"Media Type";
+
+    self.customPreviewCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    self.customPreviewCell.accessoryView = [[UISwitch alloc] init];
+    ((UISwitch *)self.customPreviewCell.accessoryView).on = [self.options[MediaPickerOptionsCustomPreview] boolValue];
+    self.customPreviewCell.textLabel.text = @"Use Custom Preview Controller";
 }
 
 #pragma mark - Table view data source
@@ -105,6 +113,9 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
         case OptionsViewControllerCellMediaType:
             return self.filterMediaCell;
             break;
+        case OptionsViewControllerCellCustomPreview:
+            return self.customPreviewCell;
+            break;
         default:
             break;
     }
@@ -122,6 +133,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
              MediaPickerOptionsAllowMultipleSelection:@(((UISwitch *)self.allowMultipleSelectionCell.accessoryView).on),
              MediaPickerOptionsPostProcessingStep:@(((UISwitch *)self.postProcessingStepCell.accessoryView).on),
              MediaPickerOptionsFilterType:@(((UISegmentedControl *)self.filterMediaCell.accessoryView).selectedSegmentIndex),
+             MediaPickerOptionsCustomPreview:@(((UISwitch *)self.customPreviewCell.accessoryView).on),
              };
         
         [delegate optionsViewController:self changed:newOptions];

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -109,6 +109,15 @@
  */
 - (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker didDeselectAsset:(nonnull id<WPMediaAsset>)asset;
 
+/**
+ *  Asks the delegate for a view controller to push when previewing the specified asset.
+ *  If this method isn't implemented or returns nil, the default view controller will be used.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @param asset  The asset to be previewed.
+ */
+- (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset;
+
 @end
 
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -672,7 +672,7 @@ referenceSizeForFooterInSection:(NSInteger)section
 - (void)handleLongPressOnAsset:(UIGestureRecognizer *)gestureRecognizer {
     if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
         CGPoint location = [gestureRecognizer locationInView:self.collectionView];
-        UIViewController *viewController = [self fullscreenAssetPreviewControllerForTouchLocation:location];
+        UIViewController *viewController = [self previewControllerForTouchLocation:location];
 
         if (viewController) {
             [self.navigationController pushViewController:viewController animated:YES];
@@ -680,7 +680,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     }
 }
 
-- (nullable WPAssetViewController *)fullscreenAssetPreviewControllerForTouchLocation:(CGPoint)location
+- (nullable UIViewController *)previewControllerForTouchLocation:(CGPoint)location
 {
     self.assetIndexInPreview = [self.collectionView indexPathForItemAtPoint:location];
     if (!self.assetIndexInPreview) {
@@ -692,6 +692,27 @@ referenceSizeForFooterInSection:(NSInteger)section
         return nil;
     }
 
+    return [self previewViewControllerForAsset:asset];
+}
+
+- (UIViewController *)previewViewControllerForAsset:(id <WPMediaAsset>)asset
+{
+    UIViewController *previewViewController = nil;
+
+    if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:previewViewControllerForAsset:)]) {
+        previewViewController = [self.mediaPickerDelegate mediaPickerController:self
+                                                  previewViewControllerForAsset:asset];
+    }
+
+    if (!previewViewController) {
+        previewViewController = [self defaultPreviewViewControllerForAsset:asset];
+    }
+
+    return previewViewController;
+}
+
+- (UIViewController *)defaultPreviewViewControllerForAsset:(id <WPMediaAsset>)asset
+{
     WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
     fullScreenImageVC.asset = asset;
     fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
@@ -711,7 +732,7 @@ referenceSizeForFooterInSection:(NSInteger)section
         [previewingContext setSourceRect:rect];
     }
 
-    return [self fullscreenAssetPreviewControllerForTouchLocation:convertedLocation];
+    return [self previewControllerForTouchLocation:convertedLocation];
 }
 
 - (void)previewingContext:(id <UIViewControllerPreviewing>)previewingContext commitViewController:(UIViewController *)viewControllerToCommit


### PR DESCRIPTION
This PR adds a delegate method allowing the delegate to provide a custom preview view controller instead of the default one. I've updated the Example project to add an option you can toggle on to use a demo custom view controller.

You can then test the custom controller by long pressing or force pressing on an item in the collection view.

Needs review: @SergioEstevao 