### PR TITLE
Fixes nullability warnings in WPMediaPickerViewController.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -123,7 +123,7 @@
 
 @interface WPMediaPickerViewController : UICollectionViewController
 
-@property (nonatomic, readonly) NSMutableArray *selectedAssets;
+@property (nonatomic, readonly, nonnull) NSMutableArray *selectedAssets;
 /**
  If set the picker will show a cell that allows capture of new media, that can be used immediatelly
  */
@@ -152,17 +152,17 @@
 /**
   The object that acts as the data source of the media picker.
  */
-@property (nonatomic, weak) id<WPMediaCollectionDataSource> dataSource;
+@property (nonatomic, weak, nullable) id<WPMediaCollectionDataSource> dataSource;
 
 /**
  The object that acts as the data source of the media picker.
  */
-@property (nonatomic, weak) id<WPMediaPickerViewControllerDelegate> mediaPickerDelegate;
+@property (nonatomic, weak, nullable) id<WPMediaPickerViewControllerDelegate> mediaPickerDelegate;
 
 /**
  Allows to set a group as the current display group on the data source. 
  */
-- (void)setGroup:(id<WPMediaGroup>)group;
+- (void)setGroup:(nonnull id<WPMediaGroup>)group;
 
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -12,7 +12,6 @@
 <
  UIImagePickerControllerDelegate,
  UINavigationControllerDelegate,
- WPMediaGroupPickerViewControllerDelegate,
  UIPopoverPresentationControllerDelegate,
  UICollectionViewDelegateFlowLayout,
  WPAssetViewControllerDelegate,

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -3,7 +3,11 @@
 #import "WPMediaGroupPickerViewController.h"
 #import "WPPHAssetDataSource.h"
 
-@interface WPNavigationMediaPickerViewController () <UINavigationControllerDelegate>
+@interface WPNavigationMediaPickerViewController () <
+UINavigationControllerDelegate,
+WPMediaGroupPickerViewControllerDelegate,
+UIPopoverPresentationControllerDelegate
+>
 @property (nonatomic, strong) UINavigationController *internalNavigationController;
 @property (nonatomic, strong) WPMediaPickerViewController *mediaPicker;
 @property (nonatomic, strong) UIButton *titleButton;

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -19,7 +19,7 @@
 
 + (instancetype)sharedInstance
 {
-    static id<WPMediaCollectionDataSource> assetSource = nil;
+    static WPPHAssetDataSource *assetSource = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         assetSource = [[WPPHAssetDataSource alloc] init];


### PR DESCRIPTION
I think our recent refactoring introduced a few nullability warnings which I was seeing once pulling the library into WPiOS. This should fix them.

<img width="1150" alt="screen shot 2017-03-07 at 17 52 09" src="https://cloud.githubusercontent.com/assets/4780/23670182/d0749cce-035e-11e7-8bca-a8a99de655ce.png">

To test:

* Check I've used the correct nullability types
* Update the Podfile in a local copy of WPiOS to point to this branch and ensure that you don't see any nullability warnings when building.