### PR TITLE
Tweaks required for Media Library deletion in WPiOS

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -165,5 +165,10 @@
  */
 - (void)setGroup:(nonnull id<WPMediaGroup>)group;
 
+/**
+ * Clears the current asset selection in the picker.
+ */
+- (void)clearSelectedAssets:(BOOL)animated;
+
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -111,7 +111,8 @@
 
 /**
  *  Asks the delegate for a view controller to push when previewing the specified asset.
- *  If this method isn't implemented or returns nil, the default view controller will be used.
+ *  If this method isn't implemented, the default view controller will be used.
+ *  If it returns nil, no preview will be displayed.
  *
  *  @param picker The controller object managing the assets picker interface.
  *  @param asset  The asset to be previewed.

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -709,18 +709,12 @@ referenceSizeForFooterInSection:(NSInteger)section
 
 - (UIViewController *)previewViewControllerForAsset:(id <WPMediaAsset>)asset
 {
-    UIViewController *previewViewController = nil;
-
     if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:previewViewControllerForAsset:)]) {
-        previewViewController = [self.mediaPickerDelegate mediaPickerController:self
-                                                  previewViewControllerForAsset:asset];
+        return [self.mediaPickerDelegate mediaPickerController:self
+                                 previewViewControllerForAsset:asset];
     }
 
-    if (!previewViewController) {
-        previewViewController = [self defaultPreviewViewControllerForAsset:asset];
-    }
-
-    return previewViewController;
+    return [self defaultPreviewViewControllerForAsset:asset];
 }
 
 - (UIViewController *)defaultPreviewViewControllerForAsset:(id <WPMediaAsset>)asset

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -139,6 +139,15 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     return self.allowCaptureOfMedia && [self isMediaDeviceAvailable] && !self.refreshGroupFirstTime;
 }
 
+- (void)setAllowMultipleSelection:(BOOL)allowMultipleSelection
+{
+    _allowMultipleSelection = allowMultipleSelection;
+
+    if (self.isViewLoaded) {
+        self.collectionView.allowsMultipleSelection = allowMultipleSelection;
+    }
+}
+
 #pragma mark - UICollectionViewDataSource
 
 -(void)updateDataWithRemoved:(NSIndexSet *)removed inserted:(NSIndexSet *)inserted changed:(NSIndexSet *)changed moved:(NSArray<id<WPMediaMove>> *)moves {

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -148,6 +148,15 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     }
 }
 
+- (void)clearSelectedAssets:(BOOL)animated
+{
+    for (NSIndexPath *indexPath in [self.collectionView indexPathsForSelectedItems]) {
+        [self.collectionView deselectItemAtIndexPath:indexPath animated:animated];
+    }
+
+    [self.selectedAssets removeAllObjects];
+}
+
 #pragma mark - UICollectionViewDataSource
 
 -(void)updateDataWithRemoved:(NSIndexSet *)removed inserted:(NSIndexSet *)inserted changed:(NSIndexSet *)changed moved:(NSArray<id<WPMediaMove>> *)moves {


### PR DESCRIPTION
This PR makes a few tweaks / additions that are required to support the Media Library deletion PR for https://github.com/wordpress-mobile/WordPress-iOS/pull/6858. 

**Changes:**

* If the custom preview view controller delegate method `mediaPickerController:previewViewControllerForAsset:` is implemented but returns `nil`, we don't show a custom preview. Previously we'd show the default one, but now you can do that just by not implementing this delegate method.
* If `allowsMultipleSelection` is changed after the collection view is instantiated, we now update the collection view's matching property. Previously, you could only set this once.
* Added a method for clearing the current selection in the collection view.
