### PR TITLE
Issue/135: Don't silently pass through face up/down device orientations

### DIFF
--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -100,7 +100,7 @@
                 self.captureVideoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
                 self.captureVideoPreviewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
                 self.captureVideoPreviewLayer.frame = viewLayer.bounds;
-                self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]];
+                self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
                 [viewLayer addSublayer:_captureVideoPreviewLayer];
             });
         }
@@ -110,17 +110,23 @@
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
     if (self.captureVideoPreviewLayer.connection.supportsVideoOrientation) {
-        self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]];
+        self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
     }
 }
 
-- (AVCaptureVideoOrientation)videoOrientationForDeviceOrientation:(UIDeviceOrientation)orientation
+- (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation
 {
-    if (orientation == UIDeviceOrientationFaceUp || orientation == UIDeviceOrientationFaceDown) {
-        return AVCaptureVideoOrientationPortrait;
+    switch (orientation) {
+        case UIInterfaceOrientationPortrait:
+            return AVCaptureVideoOrientationPortrait;
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return AVCaptureVideoOrientationPortraitUpsideDown;
+        case UIInterfaceOrientationLandscapeLeft:
+            return AVCaptureVideoOrientationLandscapeLeft;
+        case UIInterfaceOrientationLandscapeRight:
+            return AVCaptureVideoOrientationLandscapeRight;
+        default:return AVCaptureVideoOrientationPortrait;
     }
-
-    return (AVCaptureVideoOrientation)orientation;
 }
 
 - (BOOL)isAccessibilityElement

--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -100,7 +100,7 @@
                 self.captureVideoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
                 self.captureVideoPreviewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
                 self.captureVideoPreviewLayer.frame = viewLayer.bounds;
-                self.captureVideoPreviewLayer.connection.videoOrientation = (AVCaptureVideoOrientation)[[UIDevice currentDevice] orientation];
+                self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]];
                 [viewLayer addSublayer:_captureVideoPreviewLayer];
             });
         }
@@ -110,8 +110,17 @@
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
     if (self.captureVideoPreviewLayer.connection.supportsVideoOrientation) {
-        self.captureVideoPreviewLayer.connection.videoOrientation = (AVCaptureVideoOrientation)[[UIDevice currentDevice] orientation];
+        self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]];
     }
+}
+
+- (AVCaptureVideoOrientation)videoOrientationForDeviceOrientation:(UIDeviceOrientation)orientation
+{
+    if (orientation == UIDeviceOrientationFaceUp || orientation == UIDeviceOrientationFaceDown) {
+        return AVCaptureVideoOrientationPortrait;
+    }
+
+    return (AVCaptureVideoOrientation)orientation;
 }
 
 - (BOOL)isAccessibilityElement


### PR DESCRIPTION
Fixes #135.

The camera preview image was getting flipped when holding the device in portrait and then tilting it forward (as though you were going to point it downwards). This seemed to be because we were casting `UIDeviceOrientation` directly to `AVCaptureVideoOrientation`, but `AVCaptureVideoOrientation` has two extra Face Up / Face Down cases that the AV enum doesn't have. To fix the issue, we convert either of those cases to `AVCaptureVideoOrientationPortrait`.

To test:

* Run on a device
* Open the picker and look at the camera preview cell
* Hold the device in portrait
* Slowly tilt the device forward until you're pointing the camera down at the floor. Check the preview image is still orientated correctly
* Check that landscape orientations still work correctly too.

Needs review: @SergioEstevao 