### PR TITLE
Tweak cell layout calculations to avoid large gaps between cells.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -124,20 +124,43 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
 
 - (void)setupLayout
 {
-    CGFloat minWidth = MIN (self.view.frame.size.width, self.view.frame.size.height);
+    CGFloat frameWidth = self.view.frame.size.width;
+    CGFloat frameHeight = self.view.frame.size.height;
+    CGFloat minFrameWidth = MIN(frameWidth, frameHeight);
+
     // Configure collection view layout
     CGFloat numberOfPhotosForLine = 4;
-    CGFloat spaceBetweenPhotos = 1.0f;
-    CGFloat leftRightInset = 0;
+    CGFloat photoSpacing = 1.0f;
     CGFloat topBottomInset = 5;
-    
-    CGFloat width = floorf((minWidth - (((numberOfPhotosForLine -1) * spaceBetweenPhotos)) + (2*leftRightInset)) / numberOfPhotosForLine);
-    
-    self.layout.itemSize = CGSizeMake(width, width);
-    self.layout.minimumInteritemSpacing = spaceBetweenPhotos;
-    self.layout.minimumLineSpacing = spaceBetweenPhotos;
-    self.layout.sectionInset = UIEdgeInsetsMake(topBottomInset, leftRightInset, topBottomInset, leftRightInset);
 
+    CGFloat cellSize = [self cellSizeForPhotosPerLineCount:numberOfPhotosForLine
+                                              photoSpacing:photoSpacing
+                                                frameWidth:minFrameWidth];
+
+    // Check the actual width of the content based on the computed cell size
+    // How many photos are we actually fitting per line?
+    CGFloat totalSpacing = (numberOfPhotosForLine - 1) * photoSpacing;
+    numberOfPhotosForLine = floorf((frameWidth - totalSpacing) / cellSize);
+
+    CGFloat contentWidth = (numberOfPhotosForLine * cellSize) + totalSpacing;
+
+    // If we have gaps in our layout, adjust to fit
+    if (contentWidth < frameWidth) {
+        cellSize = [self cellSizeForPhotosPerLineCount:numberOfPhotosForLine
+                                          photoSpacing:photoSpacing
+                                            frameWidth:frameWidth];
+    }
+
+    self.layout.itemSize = CGSizeMake(cellSize, cellSize);
+    self.layout.minimumInteritemSpacing = photoSpacing;
+    self.layout.minimumLineSpacing = photoSpacing;
+    self.layout.sectionInset = UIEdgeInsetsMake(topBottomInset, 0, topBottomInset, 0);
+}
+
+- (CGFloat)cellSizeForPhotosPerLineCount:(NSUInteger)photosPerLine photoSpacing:(CGFloat)photoSpacing frameWidth:(CGFloat)frameWidth
+{
+    CGFloat totalSpacing = (photosPerLine - 1) * photoSpacing;
+    return floorf((frameWidth - totalSpacing) / photosPerLine);
 }
 
 - (void)viewWillLayoutSubviews {


### PR DESCRIPTION
This PR makes a few tweaks to the cell layout logic of the collection view to avoid large gaps between cells when displayed at certain sizes. After calculating the cell size, we simply check whether all of the available space is filled with cells. If not, we floor the number of cells we can fit into the space and recalculate the cell width based on that.

Before:

![simulator screen shot 28 apr 2017 16 14 36](https://cloud.githubusercontent.com/assets/4780/25535065/ca8f1ab2-2c2d-11e7-9cf2-f2f1dbf87634.png)

After:

![simulator screen shot 28 apr 2017 16 06 13](https://cloud.githubusercontent.com/assets/4780/25535054/bd9453fe-2c2d-11e7-80b5-28d423f08c0a.png)

To test:

* Point WPiOS to this branch and open the media library in landscape. You shouldn't see any large gaps between cells. 
* Check iPhone still looks correct!