### PR TITLE
Speed up the group picker 🏎 💨 

### DIFF
--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -108,6 +108,7 @@ static CGFloat const WPMediaGroupCellHeight = 50.0f;
     } else {
         cell.accessoryType = UITableViewCellAccessoryNone;
     }
+
     return cell;
 }
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -16,7 +16,9 @@
 
 @end
 
-@implementation WPPHAssetDataSource
+@implementation WPPHAssetDataSource {
+    id<WPMediaGroup> _selectedGroup;
+}
 
 + (instancetype)sharedInstance
 {
@@ -225,6 +227,14 @@
     }
 }
 
+- (void)setActiveAssetsCollection:(PHAssetCollection *)activeAssetsCollection
+{
+    if (_activeAssetsCollection != activeAssetsCollection) {
+        _activeAssetsCollection = activeAssetsCollection;
+        _selectedGroup = nil;
+    }
+}
+
 #pragma mark - WPMediaCollectionDataSource
 
 - (NSInteger)numberOfGroups
@@ -239,7 +249,12 @@
 
 - (id<WPMediaGroup>)selectedGroup
 {
-    return [[PHAssetCollectionForWPMediaGroup alloc] initWithCollection:self.activeAssetsCollection mediaType:self.mediaTypeFilter];
+    if (!_selectedGroup) {
+        _selectedGroup = [[PHAssetCollectionForWPMediaGroup alloc] initWithCollection:self.activeAssetsCollection
+                                                                            mediaType:self.mediaTypeFilter];
+    }
+
+    return _selectedGroup;
 }
 
 - (void)setSelectedGroup:(id<WPMediaGroup>)group


### PR DESCRIPTION
This PR does a little to address https://github.com/wordpress-mobile/WordPress-iOS/issues/6971, by speeding up the appearance and scrolling of the group picker. I noticed that the call to `fetchAssetsInAssetCollection` was quite expensive so I moved around a few places where we were calling that. 

I also cached the `selectedGroup` of the data source, as we were recreating it every time we accessed the property (we accessed on every `cellForRowForIndexPath:`), which was causing choppy scrolling.

The result is two big improvements to the performance of the group picker:

1) The initial appearance of the picker after tapping the All Photos header button should be almost instant now. Previously, it was taking 1 - 2 seconds before _anything happened_ to load my photo library.
2) Scrolling through the list in the picker should be much smoother. Previously, it was quite choppy for me – particularly scrolling back to the top of the list would stick for a second or two.

To test:

* Run the demo app on a device, preferably one that has a large media library.
* Tap the All Photos header in the picker and see how long the dropdown takes to appear
* Try scrolling
* Check selecting a group still works

Needs review: @SergioEstevao 
@astralbodies would you mind giving this a whirl too, as I know you have a large media library and you previously looked at our performance issues?