### PR TITLE
Improve data fetch performance

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -126,6 +126,10 @@
     _quickInputTextField.borderStyle = UITextBorderStyleRoundedRect;
     _quickInputTextField.delegate = self;
 
+    return _quickInputTextField;
+}
+
+- (void)setupMediaKeyboardForInputField {
     self.mediaInputViewController = [[WPInputMediaPickerViewController alloc] init];
 
     [self addChildViewController:self.mediaInputViewController];
@@ -135,8 +139,6 @@
     self.mediaInputViewController.mediaPickerDelegate = self;
     self.mediaInputViewController.mediaPicker.viewControllerToUseToPresent = self;
     _quickInputTextField.inputAccessoryView = self.mediaInputViewController.mediaToolbar;
-
-    return _quickInputTextField;
 }
 
 - (id<WPMediaCollectionDataSource>)defaultDataSource
@@ -154,6 +156,7 @@
 - (void)mediaPickerControllerDidCancel:(WPMediaPickerViewController *)picker
 {
     if (picker == self.mediaInputViewController.mediaPicker) {
+        self.quickInputTextField.inputView = nil;
         [self.quickInputTextField resignFirstResponder];
         return;
     }
@@ -167,6 +170,7 @@
     [self.tableView reloadData];
     
     if (picker == self.mediaInputViewController.mediaPicker) {
+        self.quickInputTextField.inputView = nil;
         [self.quickInputTextField resignFirstResponder];
         return;
     }
@@ -256,6 +260,7 @@
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField
 {
     if (textField == self.quickInputTextField) {
+        [self setupMediaKeyboardForInputField];
         self.mediaInputViewController.mediaPicker.showMostRecentFirst = [self.options[MediaPickerOptionsShowMostRecentFirst] boolValue];
         self.mediaInputViewController.mediaPicker.allowCaptureOfMedia = [self.options[MediaPickerOptionsShowCameraCapture] boolValue];
         self.mediaInputViewController.mediaPicker.preferFrontCamera = [self.options[MediaPickerOptionsPreferFrontCamera] boolValue];

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -275,11 +275,7 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
             [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length]) animated:NO];
             [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length] - (self.refreshControl.frame.size.height)) animated:animated];
             [self.refreshControl beginRefreshing];
-        }
-        // NOTE: Sergio Estevao (2015-11-19)
-        // Clean all assets and refresh collection view when the group was changed
-        // This avoid to see data from previous group while the new one is loading.
-        [self.collectionView reloadData];
+        }        
     }
     self.collectionView.allowsSelection = NO;
     self.collectionView.allowsMultipleSelection = NO;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -169,6 +169,16 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     [self setupLayout];
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    [self.captureCell stopCaptureOnCompletion:nil];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.captureCell startCapture];
+}
+
 #pragma mark - Actions
 
 - (void)pullToRefresh:(id)sender
@@ -600,9 +610,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     imagePickerController.cameraDevice = [self cameraDevice];
     imagePickerController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
-    [self.viewControllerToUseToPresent presentViewController:imagePickerController animated:YES completion:^{
-        [self.captureCell stopCaptureOnCompletion:nil];
-    }];
+    [self.viewControllerToUseToPresent presentViewController:imagePickerController animated:YES completion:nil];
 }
 
 - (UIImagePickerControllerCameraDevice)cameraDevice
@@ -717,15 +725,12 @@ referenceSizeForFooterInSection:(NSInteger)section
 {
     [picker dismissViewControllerAnimated:YES completion:^{
         [self processMediaCaptured:info];
-        [self.captureCell startCapture];
     }];
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
-    [picker dismissViewControllerAnimated:YES completion:^{
-        [self.captureCell startCapture];
-    }];
+    [picker dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)setGroup:(id<WPMediaGroup>)group {

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -601,7 +601,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     imagePickerController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
     [self.viewControllerToUseToPresent presentViewController:imagePickerController animated:YES completion:^{
-
+        [self.captureCell stopCaptureOnCompletion:nil];
     }];
 }
 
@@ -717,12 +717,14 @@ referenceSizeForFooterInSection:(NSInteger)section
 {
     [picker dismissViewControllerAnimated:YES completion:^{
         [self processMediaCaptured:info];
+        [self.captureCell startCapture];
     }];
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
     [picker dismissViewControllerAnimated:YES completion:^{
+        [self.captureCell startCapture];
     }];
 }
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -570,22 +570,6 @@ referenceSizeForFooterInSection:(NSInteger)section
     }];
 }
 
-- (void)animateCaptureCellSelection:(UIView *)cell completion:(void (^)())completionBlock
-{
-    [UIView animateKeyframesWithDuration:0.5 delay:0 options:UIViewKeyframeAnimationOptionCalculationModePaced animations:^{
-        [UIView addKeyframeWithRelativeStartTime:0.5 relativeDuration:1 animations:^{
-            CGRect frame = self.view.frame;
-            frame.origin.x += self.collectionView.contentOffset.x;
-            frame.origin.y += self.collectionView.contentOffset.y;
-            cell.frame = frame;
-        }];
-    } completion:^(BOOL finished) {
-        if(completionBlock){
-            completionBlock();
-        }
-    }];
-}
-
 #pragma mark - Media Capture
 
 - (BOOL)isMediaDeviceAvailable

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -443,13 +443,15 @@ referenceSizeForFooterInSection:(NSInteger)section
     if ((kind == UICollectionElementKindSectionHeader && self.showMostRecentFirst) ||
        (kind == UICollectionElementKindSectionFooter && !self.showMostRecentFirst))
     {
-        self.captureCell = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:NSStringFromClass([WPMediaCapturePreviewCollectionView class]) forIndexPath:indexPath];
-        if (self.captureCell.gestureRecognizers == nil) {
-            UIGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showCapture)];
-            [self.captureCell addGestureRecognizer:tapGestureRecognizer];
+        if (!self.captureCell) {
+            self.captureCell = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:NSStringFromClass([WPMediaCapturePreviewCollectionView class]) forIndexPath:indexPath];
+            if (self.captureCell.gestureRecognizers == nil) {
+                UIGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showCapture)];
+                [self.captureCell addGestureRecognizer:tapGestureRecognizer];
+            }
+            self.captureCell.preferFrontCamera = self.preferFrontCamera;
+            [self.captureCell startCapture];
         }
-        self.captureCell.preferFrontCamera = self.preferFrontCamera;
-        [self.captureCell startCapture];
         return self.captureCell;
     }
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -113,15 +113,17 @@
             }
             return;
         }
-        if (self.refreshGroups) {
-            [[[self class] sharedImageManager] stopCachingImagesForAllAssets];
-            [self loadGroupsWithSuccess:^{
-                self.refreshGroups = NO;
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            if (self.refreshGroups) {
+                [[[self class] sharedImageManager] stopCachingImagesForAllAssets];
+                [self loadGroupsWithSuccess:^{
+                    self.refreshGroups = NO;
+                    [self loadAssetsWithSuccess:successBlock failure:failureBlock];
+                } failure:failureBlock];
+            } else {
                 [self loadAssetsWithSuccess:successBlock failure:failureBlock];
-            } failure:failureBlock];
-        } else {
-            [self loadAssetsWithSuccess:successBlock failure:failureBlock];
-        }
+            }
+        });
     }];
 }
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -514,9 +514,10 @@
 @interface PHAssetCollectionForWPMediaGroup()
 
 @property(nonatomic, strong) PHAssetCollection *collection;
-@property(nonatomic) NSUInteger assetCount;
+@property(nonatomic) NSInteger assetCount;
 @property(nonatomic, strong) PHAsset *posterAsset;
 @property(nonatomic, assign) WPMediaType mediaType;
+@property(nonatomic, strong) PHFetchResult *fetchResult;
 
 @end
 
@@ -529,13 +530,8 @@
         _collection = collection;
         _mediaType = mediaType;
 
-        PHFetchOptions *fetchOptions = [PHFetchOptions new];
-        fetchOptions.predicate = [WPPHAssetDataSource predicateForFilterMediaType:_mediaType];
-        PHFetchResult *result = [PHAsset fetchKeyAssetsInAssetCollection:_collection options:fetchOptions];
-        _posterAsset = [result lastObject];
-
-        _assetCount = [[PHAsset fetchAssetsInAssetCollection:_collection options:fetchOptions] count];
-
+        _assetCount = NSNotFound;
+        _posterAsset = nil;
     }
     return self;
 }
@@ -573,7 +569,29 @@
         return count;
     }
 
+    if (self.assetCount == NSNotFound) {
+        self.assetCount = [self.fetchResult count];
+    }
+
     return self.assetCount;
+}
+
+- (PHFetchResult *)fetchResult {
+    if (!_fetchResult) {
+        PHFetchOptions *fetchOptions = [PHFetchOptions new];
+        fetchOptions.predicate = [WPPHAssetDataSource predicateForFilterMediaType:_mediaType];
+        _fetchResult = [PHAsset fetchAssetsInAssetCollection:_collection options:fetchOptions];
+
+    }
+    return _fetchResult;
+}
+
+- (PHAsset *)posterAsset {
+    if (!_posterAsset) {
+        _posterAsset = [[self fetchResult] lastObject];
+    }
+
+    return _posterAsset;
 }
 
 @end


### PR DESCRIPTION
This PR tries to further address performance issues when trying to display the Photo Library data.

It implements three things:

 - Make sure that the data update is made on a background thread.
 - Only fetch group data (count and poster) when needed.
 - Don't reload collection when refresh starts.

To test:
 - Open the demo app and see if the initial display and scrolling performance is good
 - Switch collection/groups/albums to see if all works correctly.
 - Capture an image using the capture header and check if all updates correctly.
 - Capture an image using the screenshot capture to see if all updates correctly
