### PR TITLE
Fix cases where asset date returns nil.

### DIFF
--- a/Example/Tests/WPDateTimeHelpersTests.m
+++ b/Example/Tests/WPDateTimeHelpersTests.m
@@ -50,5 +50,8 @@
     XCTAssertEqualObjects(@"1:01:07", result);
 }
 
+- (void)testUserFriendlyStringDateFromDate {    
+    XCTAssertThrows([WPDateTimeHelpers userFriendlyStringDateFromDate:nil]);
+}
 @end
 

--- a/Pod/Classes/WPAssetViewController.m
+++ b/Pod/Classes/WPAssetViewController.m
@@ -73,17 +73,21 @@
     }
     UILabel *titleLabel = [[UILabel alloc] init];
     titleLabel.textColor = self.navigationController.navigationBar.tintColor;
-    NSString *dateString = [WPDateTimeHelpers userFriendlyStringDateFromDate:self.asset.date];
-    NSString *timeString = [WPDateTimeHelpers userFriendlyStringTimeFromDate:self.asset.date];
+    if (self.asset.date != nil) {
+        NSString *dateString = [WPDateTimeHelpers userFriendlyStringDateFromDate:self.asset.date];
+        NSString *timeString = [WPDateTimeHelpers userFriendlyStringTimeFromDate:self.asset.date];
 
-    NSAttributedString *dateAttributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@\n", dateString] attributes:@{NSFontAttributeName: titleLabel.font}];
-    NSAttributedString *timeAttributedString = [[NSAttributedString alloc] initWithString:timeString attributes:@{NSFontAttributeName: [titleLabel.font fontWithSize:floorf(titleLabel.font.pointSize * 0.75)]}];
+        NSAttributedString *dateAttributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@\n", dateString] attributes:@{NSFontAttributeName: titleLabel.font}];
+        NSAttributedString *timeAttributedString = [[NSAttributedString alloc] initWithString:timeString attributes:@{NSFontAttributeName: [titleLabel.font fontWithSize:floorf(titleLabel.font.pointSize * 0.75)]}];
 
-    NSMutableAttributedString *titleAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString:dateAttributedString];
-    [titleAttributedString appendAttributedString:timeAttributedString];
-
+        NSMutableAttributedString *titleAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString:dateAttributedString];
+        [titleAttributedString appendAttributedString:timeAttributedString];
+        titleLabel.attributedText = titleAttributedString;
+    } else {
+        titleLabel.text = @"";
+    }
     titleLabel.numberOfLines = 2;
-    titleLabel.attributedText = titleAttributedString;
+
     titleLabel.textAlignment = NSTextAlignmentCenter;
     [titleLabel sizeToFit];
     self.navigationItem.titleView = titleLabel;

--- a/Pod/Classes/WPDateTimeHelpers.m
+++ b/Pod/Classes/WPDateTimeHelpers.m
@@ -3,6 +3,7 @@
 @implementation WPDateTimeHelpers
 
 + (NSString *)userFriendlyStringDateFromDate:(NSDate *)date {
+    NSAssert(date != nil, @"Date cannot be nil");
     NSDate *now = [NSDate date];
     NSString *dateString = [[[self class] sharedDateFormatter] stringFromDate:date];
 
@@ -19,6 +20,7 @@
 }
 
 + (NSString *)userFriendlyStringTimeFromDate:(NSDate *)date {
+    NSAssert(date != nil, @"Date cannot be nil");
     return [[[self class] sharedTimeFormatter] stringFromDate:date];
 }
 

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -122,7 +122,7 @@ static const CGFloat TimeForFadeAnimation = 0.3;
 - (void)configureAccessibility
 {
     NSString *accessibilityLabel = @"";
-    NSString *formattedDate = NSLocalizedString(@"Unknow creation date", @"Label to use when creation date from media asset is not know.");
+    NSString *formattedDate = NSLocalizedString(@"Unknown creation date", @"Label to use when creation date from media asset is not know.");
     NSDate *assetDate = _asset.date;
     if (assetDate) {
         formattedDate = [NSString stringWithFormat:@"%@ %@",[WPDateTimeHelpers userFriendlyStringDateFromDate:assetDate], [WPDateTimeHelpers userFriendlyStringTimeFromDate:assetDate]];

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -122,7 +122,11 @@ static const CGFloat TimeForFadeAnimation = 0.3;
 - (void)configureAccessibility
 {
     NSString *accessibilityLabel = @"";
-    NSString *formattedDate = [NSString stringWithFormat:@"%@ %@",[WPDateTimeHelpers userFriendlyStringDateFromDate:_asset.date], [WPDateTimeHelpers userFriendlyStringTimeFromDate:_asset.date]];
+    NSString *formattedDate = NSLocalizedString(@"Unknow creation date", @"Label to use when creation date from media asset is not know.");
+    NSDate *assetDate = _asset.date;
+    if (assetDate) {
+        formattedDate = [NSString stringWithFormat:@"%@ %@",[WPDateTimeHelpers userFriendlyStringDateFromDate:assetDate], [WPDateTimeHelpers userFriendlyStringTimeFromDate:assetDate]];
+    }
 
     switch (self.asset.assetType) {
         case WPMediaTypeImage:


### PR DESCRIPTION
Some assets can return nil dates and our formatters for user friendly dates where complaining this was an error and in the future will be an exception/crash.

To avoid this situation I added some checks for nil, an Unit Test and some nil handling on the project.

To test:
 - Run unit tests to check if no error occurs.
 - Double check on the main project if no exception when scrolling media libraries.

