### PR TITLE
Add begin / end loading data picker delegate methods

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -120,6 +120,18 @@
  */
 - (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset;
 
+/**
+ *  Tells the delegate that the picker will begin requesting
+ *  new data from its data source.
+ */
+- (void)mediaPickerControllerWillBeginLoadingData:(nonnull WPMediaPickerViewController *)picker;
+
+/**
+ *  Tells the delegate that the picker finished loading
+ *  new data from its data source.
+ */
+- (void)mediaPickerControllerDidEndLoadingData:(nonnull WPMediaPickerViewController *)picker;
+
 @end
 
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -290,7 +290,13 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     self.collectionView.allowsSelection = NO;
     self.collectionView.allowsMultipleSelection = NO;
     self.collectionView.scrollEnabled = NO;
+
+    if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerControllerWillBeginLoadingData:)]) {
+        [self.mediaPickerDelegate mediaPickerControllerWillBeginLoadingData:self];
+    }
+
     __weak __typeof__(self) weakSelf = self;
+
     [self.dataSource loadDataWithSuccess:^{
         __typeof__(self) strongSelf = weakSelf;
         BOOL refreshGroupFirstTime = strongSelf.refreshGroupFirstTime;
@@ -315,6 +321,8 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
                 if (refreshGroupFirstTime){
                     [strongSelf scrollToStart:NO];
                 }
+
+                [strongSelf informDelegateDidEndLoadingData];
             });
  
         });
@@ -322,9 +330,17 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
         __typeof__(self) strongSelf = weakSelf;
         strongSelf.refreshGroupFirstTime = NO;
         dispatch_async(dispatch_get_main_queue(), ^{
+            [strongSelf informDelegateDidEndLoadingData];
             [strongSelf showError:error];
         });
     }];
+}
+
+- (void)informDelegateDidEndLoadingData
+{
+    if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerControllerDidEndLoadingData:)]) {
+        [self.mediaPickerDelegate mediaPickerControllerDidEndLoadingData:self];
+    }
 }
 
 - (void)showError:(NSError *)error {


### PR DESCRIPTION
I'm currently improving the loading behaviour of the media library in WPiOS, and to do that I need the picker's delegate to know when the picker is fetching data. I've added two delegate methods that just report when the process has started / completed.

To test:

* Check out the WPiOS branch `feature/media-library-loading`.
* Open the media library for a site with an empty media library.
* Ensure that the 'fetching media...' no results view message is shown while loading.
* If you like, set breakpoints in the delegate implementations in `MediaLibraryViewController` to check they're being called.

Needs Review: @SergioEstevao 