### PR TITLE
Fix unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-osx_image: xcode8
+osx_image: xcode8.3
 sudo: false
 language: objective-c
 podfile: Example/Podfile
 before_script:
 - cd Example && pod install && cd -
 script:
-- set -o pipefail && xcodebuild build test -workspace Example/WPMediaPicker.xcworkspace -scheme WPMediaPicker-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c
+- set -o pipefail && xcodebuild build test -workspace Example/WPMediaPicker.xcworkspace -scheme WPMediaPicker-Example -sdk iphonesimulator  -destination "name=iPhone 7" ONLY_ACTIVE_ARCH=NO | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ podfile: Example/Podfile
 before_script:
 - cd Example && pod install && cd -
 script:
-- set -o pipefail && xcodebuild build -workspace Example/WPMediaPicker.xcworkspace -scheme WPMediaPicker-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c
+- set -o pipefail && xcodebuild build test -workspace Example/WPMediaPicker.xcworkspace -scheme WPMediaPicker-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty -c

--- a/Example/Tests/WPDateTimeHelpersTests.m
+++ b/Example/Tests/WPDateTimeHelpersTests.m
@@ -1,5 +1,14 @@
 #import <XCTest/XCTest.h>
-#import "WPDateTimeHelpers.h"
+
+@interface WPDateTimeHelpers : NSObject
+
++ (NSString *)userFriendlyStringDateFromDate:(NSDate *)date;
+
++ (NSString *)userFriendlyStringTimeFromDate:(NSDate *)date;
+
++ (NSString *)stringFromTimeInterval:(NSTimeInterval)timeInterval;
+
+@end
 
 @interface WPDateTimeHelpersTest : XCTestCase
 


### PR DESCRIPTION
This PR fixes the test compilation issue, that emerged after we made the WPDateTimeHelpers private to the pod.

To test:
 - Just make sure the Travis build runs the tests and they are successful.
