### PR TITLE
Break retain cycles.

### DIFF
--- a/Pod/Classes/WPMediaGroupPickerViewController.h
+++ b/Pod/Classes/WPMediaGroupPickerViewController.h
@@ -13,7 +13,7 @@
 /**
  The WPMediaCollectionDataSource that is being used to display the assets and groups. If not set the picker will create a new one.
  */
-@property (nonatomic, strong) id<WPMediaCollectionDataSource> dataSource;
+@property (nonatomic, weak) id<WPMediaCollectionDataSource> dataSource;
 
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -91,7 +91,7 @@ static CGFloat SelectAnimationTime = 0.2;
     __weak __typeof__(self) weakSelf = self;
     self.changesObserver = [self.dataSource registerChangeObserverBlock:
                             ^(BOOL incrementalChanges, NSIndexSet *removed, NSIndexSet *inserted, NSIndexSet *changed, NSArray *moves) {
-                                if (incrementalChanges && !self.refreshGroupFirstTime) {
+                                if (incrementalChanges && !weakSelf.refreshGroupFirstTime) {
                                     [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
                                 } else {
                                     [weakSelf refreshData];
@@ -290,7 +290,7 @@ static CGFloat SelectAnimationTime = 0.2;
             [strongSelf refreshSelection];
             dispatch_async(dispatch_get_main_queue(), ^{                
                 strongSelf.collectionView.allowsSelection = YES;
-                strongSelf.collectionView.allowsMultipleSelection = self.options.allowMultipleSelection;
+                strongSelf.collectionView.allowsMultipleSelection = strongSelf.options.allowMultipleSelection;
                 strongSelf.collectionView.scrollEnabled = YES;
                 [strongSelf.collectionView reloadData];
 


### PR DESCRIPTION
Fixes #128 

Found the following retain cycles:
 - Changing a group was making a retain cycle between the group picker and the data source
 - When refreshing data on the main collection view there was a retain cycle between the picker and the data source.

This retains cycles where keeping alive collection picker and data sources that then get notification messages out of place.

To test:
 - Open the demo app
 - Tap on Add
 - Capture photos, change groups, select photos
 - See that no crash happens.
