### PR TITLE
Improve options interface

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -231,12 +231,11 @@
 
 - (void) showPicker:(id) sender
 {
-    self.mediaPicker = [[WPNavigationMediaPickerViewController alloc] init];
+    self.mediaPicker = [[WPNavigationMediaPickerViewController alloc] initWithOptions:[self selectedOptions]];
     self.mediaPicker.delegate = self;
     self.pickerDataSource = [[WPPHAssetDataSource alloc] init];
     self.mediaPicker.dataSource = self.pickerDataSource;
 
-    self.mediaPicker.options = [self selectedOptions];
     self.mediaPicker.modalPresentationStyle = UIModalPresentationPopover;
     UIPopoverPresentationController *ppc = self.mediaPicker.popoverPresentationController;
     ppc.barButtonItem = sender;

--- a/Pod/Classes/WPInputMediaPickerViewController.h
+++ b/Pod/Classes/WPInputMediaPickerViewController.h
@@ -10,6 +10,14 @@
 @interface WPInputMediaPickerViewController : UIViewController
 
 /**
+ Init a WPInputMediaPickerViewController with the selection options
+
+ @param options an WPMediaPickerOption object
+ @return an initiated WPInputMediaPickerViewController with the designated options
+ */
+- (instancetype _Nonnull )initWithOptions:(WPMediaPickerOptions *_Nonnull)options;
+
+/**
 The delegate for the WPMediaPickerViewController events
 */
 @property (nonatomic, weak) _Nullable id<WPMediaPickerViewControllerDelegate> mediaPickerDelegate;

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -11,6 +11,31 @@
 
 @implementation WPInputMediaPickerViewController
 
+- (instancetype _Nonnull )initWithOptions:(WPMediaPickerOptions *_Nonnull)options {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[options copy]];
+    }
+    return self;
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[WPMediaPickerOptions new]];
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[WPMediaPickerOptions new]];
+    }
+    return self;
+}
+
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -21,8 +46,7 @@
 - (void)setupMediaPickerViewController {
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
-    self.privateDataSource = [[WPPHAssetDataSource alloc] init];
-    self.mediaPicker = [[WPMediaPickerViewController alloc] init];
+    self.privateDataSource = [[WPPHAssetDataSource alloc] init];    
     self.mediaPicker.dataSource = self.privateDataSource;
 
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -108,12 +108,16 @@ static CGFloat SelectAnimationTime = 0.2;
 }
 
 - (void)setOptions:(WPMediaPickerOptions *)options {
+    WPMediaPickerOptions *originalOptions = _options;
     _options = [options copy];
+    BOOL refreshNeeded = (originalOptions.filter != options.filter) | (originalOptions.showMostRecentFirst != options.showMostRecentFirst) | (originalOptions.allowCaptureOfMedia != options.allowCaptureOfMedia);
     if (self.viewLoaded) {
         [self.dataSource setMediaTypeFilter:options.filter];
         [self.dataSource setAscendingOrdering:!options.showMostRecentFirst];
         self.collectionView.allowsMultipleSelection = options.allowMultipleSelection;
-        [self refreshDataAnimated:NO];
+        if (refreshNeeded) {
+            [self refreshDataAnimated:NO];
+        }
     }
 }
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.h
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.h
@@ -2,6 +2,7 @@
 #import "WPMediaCollectionDataSource.h"
 #import "WPMediaPickerOptions.h"
 
+@class WPMediaPickerViewController;
 @protocol WPMediaPickerViewControllerDelegate;
 
 @interface WPNavigationMediaPickerViewController : UIViewController
@@ -17,18 +18,17 @@
 @property (nonatomic, weak) _Nullable id<WPMediaPickerViewControllerDelegate> delegate;
 
 /**
+The internal WPMediaPickerViewController that is used to display the media.
+*/
+@property (nonatomic, readonly)  WPMediaPickerViewController * _Nonnull mediaPicker;
+
+/**
  The object that acts as the data source of the media picker.
  
  @Discussion
  If no object is defined before the picker is show then the picker will use a shared data source that access the user media library.
 */
 @property (nonatomic, weak) _Nullable id<WPMediaCollectionDataSource> dataSource;
-
-/**
- Options to use on the internal WPMediaPickerViewController.
- */
-@property (nonatomic, copy) WPMediaPickerOptions * _Nonnull options;
-
 
 /**
  Pushes a given ViewController into the internal UINavigationController. Useful for post-processing steps.

--- a/Pod/Classes/WPNavigationMediaPickerViewController.h
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.h
@@ -6,6 +6,14 @@
 
 @interface WPNavigationMediaPickerViewController : UIViewController
 
+/**
+ Init a WPNavigationMediaPickerViewController with the selection options
+
+ @param options an options object
+ @return am initiated WPNavigationMediaPickerViewController
+ */
+- (instancetype _Nonnull )initWithOptions:(WPMediaPickerOptions *_Nonnull)options;
+
 @property (nonatomic, weak) _Nullable id<WPMediaPickerViewControllerDelegate> delegate;
 
 /**

--- a/Pod/Classes/WPNavigationMediaPickerViewController.h
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.h
@@ -9,8 +9,8 @@
 /**
  Init a WPNavigationMediaPickerViewController with the selection options
 
- @param options an options object
- @return am initiated WPNavigationMediaPickerViewController
+ @param options an WPMediaPickerOption object
+ @return an initiated WPNavigationMediaPickerViewController with the designated options
  */
 - (instancetype _Nonnull )initWithOptions:(WPMediaPickerOptions *_Nonnull)options;
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -21,7 +21,7 @@ static NSString *const ArrowDown = @"\u25be";
 - (instancetype)initWithOptions:(WPMediaPickerOptions *)options {
     self = [super initWithNibName:nil bundle:nil];
     if (self) {
-        _options = options;
+        _options = [options copy];
     }
     return self;
 }

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -18,6 +18,14 @@ UIPopoverPresentationControllerDelegate
 
 static NSString *const ArrowDown = @"\u25be";
 
+- (instancetype)initWithOptions:(WPMediaPickerOptions *)options {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _options = options;
+    }
+    return self;
+}
+
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
@@ -120,6 +128,11 @@ static NSString *const ArrowDown = @"\u25be";
     ppc.sourceView = sender;
     ppc.sourceRect = [sender bounds];
     [self presentViewController:groupViewController animated:YES completion:nil];
+}
+
+- (void)setOptions:(WPMediaPickerOptions *)options {
+    _options = options;
+    self.mediaPicker.options = _options;
 }
 
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -21,7 +21,7 @@ static NSString *const ArrowDown = @"\u25be";
 - (instancetype)initWithOptions:(WPMediaPickerOptions *)options {
     self = [super initWithNibName:nil bundle:nil];
     if (self) {
-        _options = [options copy];
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:options];
     }
     return self;
 }
@@ -30,9 +30,17 @@ static NSString *const ArrowDown = @"\u25be";
 {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
-        _options = [WPMediaPickerOptions new];
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[WPMediaPickerOptions new]];
     }
 
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[WPMediaPickerOptions new]];
+    }
     return self;
 }
 
@@ -57,14 +65,13 @@ static NSString *const ArrowDown = @"\u25be";
 
 - (void)setupNavigationController
 {
-    WPMediaPickerViewController *vc = [[WPMediaPickerViewController alloc] initWithOptions:self.options];
+    WPMediaPickerViewController *vc = self.mediaPicker;
     
     if (!self.dataSource) {
         self.dataSource = [WPPHAssetDataSource sharedInstance];
     }
     vc.dataSource = self.dataSource;
     vc.mediaPickerDelegate = self;
-    self.mediaPicker = vc;
 
     UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
     nav.delegate = self;
@@ -82,7 +89,7 @@ static NSString *const ArrowDown = @"\u25be";
     vc.navigationItem.titleView = self.titleButton;
     vc.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
 
-    if (self.options.allowMultipleSelection) {
+    if (self.mediaPicker.options.allowMultipleSelection) {
         vc.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(finishPicker:)];
     }
 }
@@ -129,12 +136,6 @@ static NSString *const ArrowDown = @"\u25be";
     ppc.sourceRect = [sender bounds];
     [self presentViewController:groupViewController animated:YES completion:nil];
 }
-
-- (void)setOptions:(WPMediaPickerOptions *)options {
-    _options = options;
-    self.mediaPicker.options = _options;
-}
-
 
 #pragma mark - WPMediaGroupViewControllerDelegate
 


### PR DESCRIPTION
Refactor some of the code around options to make it more consistent across the different ViewControllers.

They now all have an init method that accepts the option object.
To make further changes you need to go directly to the mediaPicker object directly.

To test:
 - Run the demo app
 - Check if options are being applied correctly to the different pickers.
