### PR TITLE
Improve selected assets

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -237,7 +237,7 @@
     self.mediaPicker.dataSource = self.pickerDataSource;
     if (self.mediaInputViewController) {
         self.mediaPicker.mediaPicker.selectedAssets = self.mediaInputViewController.mediaPicker.selectedAssets;
-        self.mediaInputViewController.mediaPicker.selectedAssets = (NSArray<WPMediaAsset> *)@[];
+        self.mediaInputViewController.mediaPicker.selectedAssets = [NSArray<WPMediaAsset> new];
     }
     self.mediaPicker.modalPresentationStyle = UIModalPresentationPopover;
     UIPopoverPresentationController *ppc = self.mediaPicker.popoverPresentationController;

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -237,6 +237,7 @@
     self.mediaPicker.dataSource = self.pickerDataSource;
     if (self.mediaInputViewController) {
         self.mediaPicker.mediaPicker.selectedAssets = self.mediaInputViewController.mediaPicker.selectedAssets;
+        self.mediaInputViewController.mediaPicker.selectedAssets = (NSArray<WPMediaAsset> *)@[];
     }
     self.mediaPicker.modalPresentationStyle = UIModalPresentationPopover;
     UIPopoverPresentationController *ppc = self.mediaPicker.popoverPresentationController;

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -229,18 +229,22 @@
     return options;
 }
 
-- (void) showPicker:(id) sender
+- (void)showPicker:(id) sender
 {
     self.mediaPicker = [[WPNavigationMediaPickerViewController alloc] initWithOptions:[self selectedOptions]];
     self.mediaPicker.delegate = self;
     self.pickerDataSource = [[WPPHAssetDataSource alloc] init];
     self.mediaPicker.dataSource = self.pickerDataSource;
-
+    if (self.mediaInputViewController) {
+        self.mediaPicker.mediaPicker.selectedAssets = self.mediaInputViewController.mediaPicker.selectedAssets;
+    }
     self.mediaPicker.modalPresentationStyle = UIModalPresentationPopover;
     UIPopoverPresentationController *ppc = self.mediaPicker.popoverPresentationController;
     ppc.barButtonItem = sender;
     
     [self presentViewController:self.mediaPicker animated:YES completion:nil];
+    [self.quickInputTextField resignFirstResponder];
+    self.wasFirstResponder = nil;
 }
 
 - (void)showOptions:(id) sender

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -100,7 +100,7 @@
 
 - (void)mediaSelected:(UIBarButtonItem *)sender {
     if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAssets:)]) {
-        [self.mediaPickerDelegate mediaPickerController:self.mediaPicker didFinishPickingAssets:[self.mediaPicker.selectedAssets copy]];
+        [self.mediaPickerDelegate mediaPickerController:self.mediaPicker didFinishPickingAssets:self.mediaPicker.selectedAssets];
         [self.mediaPicker resetState:NO];
     }
     

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -145,7 +145,7 @@
 /**
  An array with the the assets that are currently selected.
  */
-@property (nonatomic, readonly, nonnull) NSMutableArray *selectedAssets;
+@property (nonatomic, copy, nonnull) NSArray<WPMediaAsset> *selectedAssets;
 
 /**
   The object that acts as the data source of the media picker.

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -18,7 +18,7 @@
 >
 
 @property (nonatomic, strong) UICollectionViewFlowLayout *layout;
-@property (nonatomic, strong) NSMutableArray *selectedAssets;
+@property (nonatomic, strong) NSMutableArray *internalSelectedAssets;
 @property (nonatomic, strong) WPMediaCapturePreviewCollectionView *captureCell;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, strong) NSObject *changesObserver;
@@ -43,7 +43,7 @@ static CGFloat SelectAnimationTime = 0.2;
     self = [self initWithCollectionViewLayout:layout];
     if (self) {
         _layout = layout;
-        _selectedAssets = [[NSMutableArray alloc] init];
+        _internalSelectedAssets = [[NSMutableArray alloc] init];
         _options = [options copy];
         _refreshGroupFirstTime = YES;
         _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressOnAsset:)];        
@@ -195,7 +195,7 @@ static CGFloat SelectAnimationTime = 0.2;
         [self.collectionView deselectItemAtIndexPath:indexPath animated:animated];
     }
 
-    [self.selectedAssets removeAllObjects];
+    [self.internalSelectedAssets removeAllObjects];
 }
 
 - (void)resetState:(BOOL)animated {
@@ -371,9 +371,18 @@ static CGFloat SelectAnimationTime = 0.2;
     [self presentViewController:alertController animated:YES completion:nil];
 }
 
+- (void)setSelectedAssets:(NSArray *)selectedAssets {
+    self.internalSelectedAssets = [selectedAssets copy];
+    [self refreshDataAnimated: NO];
+}
+
+- (NSArray *)selectedAssets {
+    return [self.internalSelectedAssets copy];
+}
+
 - (void)refreshSelection
 {
-    NSArray *selectedAssets = [NSArray arrayWithArray:self.selectedAssets];
+    NSArray *selectedAssets = [NSArray arrayWithArray:self.internalSelectedAssets];
     NSMutableArray *stillExistingSeletedAssets = [NSMutableArray array];
     for (id<WPMediaAsset> asset in selectedAssets) {
         NSString *assetIdentifier = [asset identifier];
@@ -381,7 +390,7 @@ static CGFloat SelectAnimationTime = 0.2;
             [stillExistingSeletedAssets addObject:asset];
         }
     }
-    self.selectedAssets = stillExistingSeletedAssets;
+    self.internalSelectedAssets = stillExistingSeletedAssets;
 }
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView
@@ -486,7 +495,7 @@ referenceSizeForFooterInSection:(NSInteger)section
  */
 - (NSUInteger)positionOfAssetInSelection:(id<WPMediaAsset>)asset
 {
-    NSUInteger position = [self.selectedAssets indexOfObjectPassingTest:^BOOL(id<WPMediaAsset> loopAsset, NSUInteger idx, BOOL *stop) {
+    NSUInteger position = [self.internalSelectedAssets indexOfObjectPassingTest:^BOOL(id<WPMediaAsset> loopAsset, NSUInteger idx, BOOL *stop) {
         BOOL found =  [[asset identifier]  isEqual:[loopAsset identifier]];
         return found;
     }];
@@ -511,13 +520,13 @@ referenceSizeForFooterInSection:(NSInteger)section
         return;
     }
     if (!self.options.allowMultipleSelection) {
-        [self.selectedAssets removeAllObjects];
+        [self.internalSelectedAssets removeAllObjects];
     }
-    [self.selectedAssets addObject:asset];
+    [self.internalSelectedAssets addObject:asset];
 
     WPMediaCollectionViewCell *cell = (WPMediaCollectionViewCell *)[self.collectionView cellForItemAtIndexPath:indexPath];
     if (self.options.allowMultipleSelection) {
-        [cell setPosition:self.selectedAssets.count];
+        [cell setPosition:self.internalSelectedAssets.count];
     } else {
         [cell setPosition:NSNotFound];
     }
@@ -528,7 +537,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     }
     if (!self.options.allowMultipleSelection) {
         if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAssets:)]) {
-            [self.mediaPickerDelegate mediaPickerController:self didFinishPickingAssets:[self.selectedAssets copy]];
+            [self.mediaPickerDelegate mediaPickerController:self didFinishPickingAssets:[self.internalSelectedAssets copy]];
         }
     }
 }
@@ -551,7 +560,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     }
     NSUInteger deselectPosition = [self positionOfAssetInSelection:asset];
     if (deselectPosition != NSNotFound) {
-        [self.selectedAssets removeObjectAtIndex:deselectPosition];
+        [self.internalSelectedAssets removeObjectAtIndex:deselectPosition];
     }
 
     WPMediaCollectionViewCell *cell = (WPMediaCollectionViewCell *)[self.collectionView cellForItemAtIndexPath:indexPath];
@@ -705,12 +714,12 @@ referenceSizeForFooterInSection:(NSInteger)section
     BOOL willBeSelected = YES;
     if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:shouldSelectAsset:)]) {
         if ([self.mediaPickerDelegate mediaPickerController:self shouldSelectAsset:asset]) {
-            [self.selectedAssets addObject:asset];
+            [self.internalSelectedAssets addObject:asset];
         } else {
             willBeSelected = NO;
         }
     } else {
-        [self.selectedAssets addObject:asset];
+        [self.internalSelectedAssets addObject:asset];
     }
     
     if (!willBeSelected) {
@@ -721,7 +730,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     }
     if (!self.options.allowMultipleSelection) {
         if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAssets:)]) {
-            [self.mediaPickerDelegate mediaPickerController:self didFinishPickingAssets:[self.selectedAssets copy]];
+            [self.mediaPickerDelegate mediaPickerController:self didFinishPickingAssets:[self.internalSelectedAssets copy]];
         }
     }
     NSInteger positionToUpdate = self.options.showMostRecentFirst ? 0 : self.dataSource.numberOfAssets-1;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -373,7 +373,9 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (void)setSelectedAssets:(NSArray *)selectedAssets {
     self.internalSelectedAssets = [selectedAssets copy];
-    [self refreshDataAnimated: NO];
+    if ([self isViewLoaded]) {
+        [self refreshDataAnimated: NO];
+    }
 }
 
 - (NSArray *)selectedAssets {

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -104,7 +104,7 @@ static NSString *const ArrowDown = @"\u25be";
 - (void)finishPicker:(UIBarButtonItem *)sender
 {
     if ([self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAssets:)]) {
-        [self.delegate mediaPickerController:self.mediaPicker didFinishPickingAssets:[self.mediaPicker.selectedAssets copy]];
+        [self.delegate mediaPickerController:self.mediaPicker didFinishPickingAssets:self.mediaPicker.selectedAssets];
     }
 }
 


### PR DESCRIPTION
This PR refactor the selectedAssets method to allow changed of the selectedAssets to come from the outside of the picker and/or to be configured before the picker is show.

To test:
 - Start the demo app
 - Start the input picker
 - Select some assets
 - Tap on + to start the full screen picker
 - See if the selected assets options where passed correctly
 - Tap and untap assets and see if they updated correctly
