### PR TITLE
Select correct media types for capture after filtering.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -615,17 +615,18 @@ referenceSizeForFooterInSection:(NSInteger)section
     UIImagePickerController *imagePickerController = [[UIImagePickerController alloc] init];
     NSMutableSet *mediaTypes = [NSMutableSet setWithArray:[UIImagePickerController availableMediaTypesForSourceType:
                            UIImagePickerControllerSourceTypeCamera]];
-    switch (self.options.filter) {
-        case(WPMediaTypeImage): {
-            [mediaTypes intersectSet:[NSSet setWithArray:@[(__bridge NSString *)kUTTypeImage]]];
-        } break;
-        case(WPMediaTypeVideo): {
-            [mediaTypes intersectSet:[NSSet setWithArray:@[(__bridge NSString *)kUTTypeMovie]]];
-        } break;
-        default: {
-            //Don't intersect at all
-        }
+    NSMutableSet *mediaDesired = [NSMutableSet new];
+    if (self.options.filter & WPMediaTypeImage) {
+        [mediaDesired addObject:(__bridge NSString *)kUTTypeImage];
     }
+    if (self.options.filter & WPMediaTypeVideo) {
+        [mediaDesired addObject:(__bridge NSString *)kUTTypeMovie];
+
+    }
+    if (mediaDesired.count > 0){
+        [mediaTypes intersectSet:mediaDesired];
+    }
+        
     imagePickerController.mediaTypes = [mediaTypes allObjects];
     imagePickerController.delegate = self;
     imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;


### PR DESCRIPTION
This PR fix a issue where the filtering of media type for media capture was done in a incorrect way.

Luckily for the current filter types the code worked correctly but is better to fix it.


To test:
 - Start the demo app on a device
 - Tap on the capture cell, depending of the media filter that that is selected on options you should see
 - If just image: just option to capture photo
 - If just video: just option to capture video
 - If image and video: option to capture photo or video.

