### PR TITLE
Remove camera cell from the inline picker

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -275,7 +275,6 @@
 {
     if (textField == self.quickInputTextField) {
         [self setupMediaKeyboardForInputField];
-        self.mediaInputViewController.mediaPicker.options = [self selectedOptions];        
         [self.mediaInputViewController.mediaPicker resetState:NO];
     }
     return YES;

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -275,6 +275,7 @@
 {
     if (textField == self.quickInputTextField) {
         [self setupMediaKeyboardForInputField];
+        self.mediaInputViewController.options = [self selectedOptions];
         [self.mediaInputViewController.mediaPicker resetState:NO];
     }
     return YES;

--- a/Pod/Classes/WPInputMediaPickerViewController.h
+++ b/Pod/Classes/WPInputMediaPickerViewController.h
@@ -36,6 +36,12 @@ The delegate for the WPMediaPickerViewController events
 @property (nonatomic, readonly)  WPMediaPickerViewController * _Nonnull mediaPicker;
 
 /**
+ Options passed to the internal media picker instance. Options should be set via
+ this property instead of directly on the media picker itself.
+ */
+@property (nonatomic, copy)  WPMediaPickerOptions * _Nonnull options;
+
+/**
  A toolbar that can be used as the inputAccessoryView for this inputView.
  */
 @property (nonatomic, readonly) UIToolbar * _Nonnull mediaToolbar;

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -14,7 +14,10 @@
 - (instancetype _Nonnull )initWithOptions:(WPMediaPickerOptions *_Nonnull)options {
     self = [super initWithNibName:nil bundle:nil];
     if (self) {
-        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[options copy]];
+        WPMediaPickerOptions *optionsOverride = [options copy];
+        // Always turn off media capture in the input picker
+        optionsOverride.allowCaptureOfMedia = NO;
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:optionsOverride];
     }
     return self;
 }
@@ -22,7 +25,10 @@
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
-        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[WPMediaPickerOptions new]];
+        WPMediaPickerOptions *options = [WPMediaPickerOptions new];
+        // Always turn off media capture in the input picker
+        options.allowCaptureOfMedia = NO;
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:options];
     }
     return self;
 }
@@ -30,7 +36,10 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[WPMediaPickerOptions new]];
+        WPMediaPickerOptions *options = [WPMediaPickerOptions new];
+        // Always turn off media capture in the input picker
+        options.allowCaptureOfMedia = NO;
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:options];
     }
     return self;
 }

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -14,10 +14,7 @@
 - (instancetype _Nonnull )initWithOptions:(WPMediaPickerOptions *_Nonnull)options {
     self = [super initWithNibName:nil bundle:nil];
     if (self) {
-        WPMediaPickerOptions *optionsOverride = [options copy];
-        // Always turn off media capture in the input picker
-        optionsOverride.allowCaptureOfMedia = NO;
-        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:optionsOverride];
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[self overriddenOptions:options]];
     }
     return self;
 }
@@ -26,9 +23,7 @@
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
         WPMediaPickerOptions *options = [WPMediaPickerOptions new];
-        // Always turn off media capture in the input picker
-        options.allowCaptureOfMedia = NO;
-        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:options];
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[self overriddenOptions:options]];
     }
     return self;
 }
@@ -37,9 +32,7 @@
     self = [super initWithCoder:aDecoder];
     if (self) {
         WPMediaPickerOptions *options = [WPMediaPickerOptions new];
-        // Always turn off media capture in the input picker
-        options.allowCaptureOfMedia = NO;
-        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:options];
+        _mediaPicker = [[WPMediaPickerViewController alloc] initWithOptions:[self overriddenOptions:options]];
     }
     return self;
 }
@@ -122,5 +115,24 @@
     }
 }
 
+- (void)setOptions:(WPMediaPickerOptions *)options
+{
+    self.mediaPicker.options = [self overriddenOptions:options];
+}
+
+- (WPMediaPickerOptions *)options
+{
+    return self.mediaPicker.options;
+}
+
+- (WPMediaPickerOptions *)overriddenOptions:(WPMediaPickerOptions *)options
+{
+    WPMediaPickerOptions *optionsOverride = [options copy];
+
+    // Always turn off media capture in the input picker
+    optionsOverride.allowCaptureOfMedia = NO;
+
+    return optionsOverride;
+}
 
 @end


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/7628

This PR removes the camera cell from the inline media picker by overriding the `allowCaptureOfMedia` option upon init `WPInputMediaPickerViewController`.

<img width="599" alt="napkin 45 07-31-17 3 40 38 pm" src="https://user-images.githubusercontent.com/154014/28797468-09059410-7607-11e7-8602-9388cc2b6a72.png">

You can also test this change in WPiOS via [this branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/7628-remove-camera-cell-from-inline-picker). 

![wp_1](https://user-images.githubusercontent.com/154014/28797605-7f2a2354-7607-11e7-934c-c7fc7ac2af59.png)

**To test:**
 Run the demo on a few devices (ideally an iPad and iPhone):
1. Tap the quick select assets cell in the table. Make sure the camera cell is not visible. 
2. Tap the plus icon in the upper right corner, verify the camera cell is visible.

@frosty Could you give this a looksie? Thank you!
