### PR TITLE
Use long press to preview in the inline picker

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -192,10 +192,6 @@
 }
 
 - (UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAsset:(id<WPMediaAsset>)asset {
-    if (picker == self.mediaInputViewController.mediaPicker) {
-        return nil;
-    }
-
     if (asset.assetType == WPMediaTypeAudio) {
         return nil;
     }
@@ -209,6 +205,14 @@
     assetViewController.selected = [picker.selectedAssets containsObject:asset];
     return assetViewController;
 
+}
+
+- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldPresentPreviewController:(nonnull UIViewController *)previewViewController {
+    NSLog(@"***** Should present a preview VC!");
+}
+
+- (void)mediaPickerControllerShouldDismissPreviewController:(nonnull WPMediaPickerViewController *)picker {
+    NSLog(@"***** Should dismiss a preview VC!");
 }
 
 #pragma - Actions

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -207,19 +207,6 @@
 
 }
 
-- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldPresentPreviewController:(nonnull UIViewController *)previewViewController {
-    // Presenting a preview VC (just for the input picker now)
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:previewViewController];
-    previewViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
-                                                                                                           target:self
-                                                                                                           action:@selector(mediaPickerControllerShouldDismissPreviewController:)];
-    [self presentViewController:navController animated:YES completion:nil];
-}
-
-- (void)mediaPickerControllerShouldDismissPreviewController:(nonnull WPMediaPickerViewController *)picker {
-    [self dismissViewControllerAnimated:YES completion:nil];
-}
-
 #pragma - Actions
 
 - (void) clearSelection:(id) sender

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -208,11 +208,16 @@
 }
 
 - (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldPresentPreviewController:(nonnull UIViewController *)previewViewController {
-    NSLog(@"***** Should present a preview VC!");
+    // Presenting a preview VC (just for the input picker now)
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:previewViewController];
+    previewViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                                                                           target:self
+                                                                                                           action:@selector(mediaPickerControllerShouldDismissPreviewController:)];
+    [self presentViewController:navController animated:YES completion:nil];
 }
 
 - (void)mediaPickerControllerShouldDismissPreviewController:(nonnull WPMediaPickerViewController *)picker {
-    NSLog(@"***** Should dismiss a preview VC!");
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma - Actions

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -49,8 +49,9 @@
     self.privateDataSource = [[WPPHAssetDataSource alloc] init];    
     self.mediaPicker.dataSource = self.privateDataSource;
 
-
     [self addChildViewController:self.mediaPicker];
+    [self overridePickerTraits];
+    
     self.mediaPicker.view.frame = self.view.bounds;
     self.mediaPicker.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:self.mediaPicker.view];
@@ -80,6 +81,20 @@
 
     self.mediaPicker.collectionView.collectionViewLayout = layout;
 
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self overridePickerTraits];
+}
+
+- (void)overridePickerTraits
+{
+    // Due to an inputView being displayed in its own window, the force touch peek transition
+    // doesn't display correctly. Because of this, we'll disable
+    UITraitCollection *traits = [UITraitCollection traitCollectionWithForceTouchCapability:UIForceTouchCapabilityUnavailable];
+    [self setOverrideTraitCollection:[UITraitCollection traitCollectionWithTraitsFromCollections:@[self.traitCollection, traits]] forChildViewController:self.mediaPicker];
 }
 
 - (void)setDataSource:(id<WPMediaCollectionDataSource>)dataSource {

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -92,7 +92,8 @@
 - (void)overridePickerTraits
 {
     // Due to an inputView being displayed in its own window, the force touch peek transition
-    // doesn't display correctly. Because of this, we'll disable
+    // doesn't display correctly. Because of this, we'll disable it for the input picker thus forcing
+    // long touch to be used instead.
     UITraitCollection *traits = [UITraitCollection traitCollectionWithForceTouchCapability:UIForceTouchCapabilityUnavailable];
     [self setOverrideTraitCollection:[UITraitCollection traitCollectionWithTraitsFromCollections:@[self.traitCollection, traits]] forChildViewController:self.mediaPicker];
 }

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -122,6 +122,23 @@
 - (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset;
 
 /**
+ *  Asks the delegate to present the specified view controller to preview a specific asset.
+ *  If this method isn't implemented, the view controller will be dismissed/popped by the media picker.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @param previewViewController The preview view controller to display.
+ */
+- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldPresentPreviewController:(nonnull UIViewController *)previewViewController;
+
+/**
+ *  Asks the delegate to dismiss the current preview view controller it is currently displaying.
+ *  If this method isn't implemented, the view controller will be dismissed/popped by the media picker.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ */
+- (void)mediaPickerControllerShouldDismissPreviewController:(nonnull WPMediaPickerViewController *)picker;
+
+/**
  *  Tells the delegate that the picker will begin requesting
  *  new data from its data source.
  */

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -122,23 +122,6 @@
 - (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset;
 
 /**
- *  Asks the delegate to present the specified view controller to preview a specific asset.
- *  If this method isn't implemented, the view controller will be dismissed/popped by the media picker.
- *
- *  @param picker The controller object managing the assets picker interface.
- *  @param previewViewController The preview view controller to display.
- */
-- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldPresentPreviewController:(nonnull UIViewController *)previewViewController;
-
-/**
- *  Asks the delegate to dismiss the current preview view controller it is currently displaying.
- *  If this method isn't implemented, the view controller will be dismissed/popped by the media picker.
- *
- *  @param picker The controller object managing the assets picker interface.
- */
-- (void)mediaPickerControllerShouldDismissPreviewController:(nonnull WPMediaPickerViewController *)picker;
-
-/**
  *  Tells the delegate that the picker will begin requesting
  *  new data from its data source.
  */

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -169,6 +169,7 @@
 
 /**
  View controller to use when picker needs to present another controller. By default this is set to self.
+ @note If the picker is being used within an input view, it's important to set this value to something besides the picker itself.
  */
 @property (nonatomic, weak, nullable) UIViewController *viewControllerToUseToPresent;
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -817,37 +817,34 @@ referenceSizeForFooterInSection:(NSInteger)section
 
 - (void)displayPreviewController:(UIViewController *)viewController {
     if (viewController) {
-        if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:shouldPresentPreviewController:)]) {
-            // The delegate will handle presenting the preview controller
-            [self.mediaPickerDelegate mediaPickerController:self shouldPresentPreviewController:viewController];
+        // viewControllerToUseToPresent defaults to self but could be set to nil. Reset to self if needed.
+        if (!self.viewControllerToUseToPresent) {
+            self.viewControllerToUseToPresent = self;
+        }
+
+        // Attempt to use the viewControllerToUseToPresent's nav controller, otherwise lets create a new nav controller and present it.
+        if (self.viewControllerToUseToPresent.navigationController) {
+            [self.viewControllerToUseToPresent.navigationController pushViewController:viewController animated:YES];
         } else {
-            if (self.navigationController) {
-                [self.navigationController pushViewController:viewController animated:YES];
-            } else if (self.viewControllerToUseToPresent.navigationController) {
-                [self.viewControllerToUseToPresent.navigationController pushViewController:viewController animated:YES];
-            } else {
-                UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
-                viewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
-                                                                                                                target:self
-                                                                                                                action:@selector(dismissPreviewController)];
-                [self.viewControllerToUseToPresent presentViewController:navController animated:YES completion:nil];
-            }
+            UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
+            viewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                                                                            target:self
+                                                                                                            action:@selector(dismissPreviewController)];
+            [self.viewControllerToUseToPresent presentViewController:navController animated:YES completion:nil];
         }
     }
 }
 
 - (void)dismissPreviewController {
-    if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerControllerShouldDismissPreviewController:)]) {
-        // The delegate will handle dismissing the preview controller
-        [self.mediaPickerDelegate mediaPickerControllerShouldDismissPreviewController:self];
+    // viewControllerToUseToPresent defaults to self but could be set to nil. Reset to self if needed.
+    if (!self.viewControllerToUseToPresent) {
+        self.viewControllerToUseToPresent = self;
+    }
+
+    if (self.viewControllerToUseToPresent.navigationController) {
+        [self.viewControllerToUseToPresent.navigationController popViewControllerAnimated:YES];
     } else {
-        if (self.navigationController) {
-            [self.navigationController popViewControllerAnimated:YES];
-        } else if (self.viewControllerToUseToPresent.navigationController) {
-            [self.viewControllerToUseToPresent.navigationController popViewControllerAnimated:YES];
-        } else {
-            [self.viewControllerToUseToPresent dismissViewControllerAnimated:YES completion:nil];
-        }
+        [self.viewControllerToUseToPresent dismissViewControllerAnimated:YES completion:nil];
     }
 }
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -821,8 +821,17 @@ referenceSizeForFooterInSection:(NSInteger)section
             // The delegate will handle presenting the preview controller
             [self.mediaPickerDelegate mediaPickerController:self shouldPresentPreviewController:viewController];
         } else {
-            // Default to presenting the preview via our nav controller
-            [self.navigationController pushViewController:viewController animated:YES];
+            if (self.navigationController) {
+                [self.navigationController pushViewController:viewController animated:YES];
+            } else if (self.viewControllerToUseToPresent.navigationController) {
+                [self.viewControllerToUseToPresent.navigationController pushViewController:viewController animated:YES];
+            } else {
+                UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
+                viewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                                                                                target:self
+                                                                                                                action:@selector(dismissPreviewController)];
+                [self.viewControllerToUseToPresent presentViewController:navController animated:YES completion:nil];
+            }
         }
     }
 }
@@ -832,8 +841,13 @@ referenceSizeForFooterInSection:(NSInteger)section
         // The delegate will handle dismissing the preview controller
         [self.mediaPickerDelegate mediaPickerControllerShouldDismissPreviewController:self];
     } else {
-        // Default to popping the preview VC via our nav controller
-        [self.navigationController popViewControllerAnimated:YES];
+        if (self.navigationController) {
+            [self.navigationController popViewControllerAnimated:YES];
+        } else if (self.viewControllerToUseToPresent.navigationController) {
+            [self.viewControllerToUseToPresent.navigationController popViewControllerAnimated:YES];
+        } else {
+            [self.viewControllerToUseToPresent dismissViewControllerAnimated:YES completion:nil];
+        }
     }
 }
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -177,6 +177,16 @@ static CGFloat SelectAnimationTime = 0.2;
     [self.captureCell startCapture];
 }
 
+- (UIViewController *)viewControllerToUseToPresent
+{
+    // viewControllerToUseToPresent defaults to self but could be set to nil. Reset to self if needed.
+    if (!_viewControllerToUseToPresent) {
+        _viewControllerToUseToPresent = self;
+    }
+
+    return _viewControllerToUseToPresent;
+}
+
 #pragma mark - Actions
 
 - (void)pullToRefresh:(id)sender
@@ -817,11 +827,6 @@ referenceSizeForFooterInSection:(NSInteger)section
 
 - (void)displayPreviewController:(UIViewController *)viewController {
     if (viewController) {
-        // viewControllerToUseToPresent defaults to self but could be set to nil. Reset to self if needed.
-        if (!self.viewControllerToUseToPresent) {
-            self.viewControllerToUseToPresent = self;
-        }
-
         // Attempt to use the viewControllerToUseToPresent's nav controller, otherwise lets create a new nav controller and present it.
         if (self.viewControllerToUseToPresent.navigationController) {
             [self.viewControllerToUseToPresent.navigationController pushViewController:viewController animated:YES];
@@ -836,11 +841,6 @@ referenceSizeForFooterInSection:(NSInteger)section
 }
 
 - (void)dismissPreviewController {
-    // viewControllerToUseToPresent defaults to self but could be set to nil. Reset to self if needed.
-    if (!self.viewControllerToUseToPresent) {
-        self.viewControllerToUseToPresent = self;
-    }
-
     if (self.viewControllerToUseToPresent.navigationController) {
         [self.viewControllerToUseToPresent.navigationController popViewControllerAnimated:YES];
     } else {

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -214,6 +214,19 @@ static NSString *const ArrowDown = @"\u25be";
     return [self.mediaPicker defaultPreviewViewControllerForAsset:asset];
 }
 
+// TODO: Decide if this should be here or not
+//- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldPresentPreviewController:(nonnull UIViewController *)previewViewController {
+//    if ([self.delegate respondsToSelector:@selector(mediaPickerController:shouldPresentPreviewController:)]) {
+//        [self.delegate mediaPickerController:picker shouldPresentPreviewController:previewViewController];
+//    }
+//}
+//
+//- (void)mediaPickerControllerShouldDismissPreviewController:(nonnull WPMediaPickerViewController *)picker {
+//    if ([self.delegate respondsToSelector:@selector(mediaPickerControllerShouldDismissPreviewController:)]) {
+//        [self.delegate mediaPickerControllerShouldDismissPreviewController:picker];
+//    }
+//}
+
 - (void)mediaPickerControllerWillBeginLoadingData:(nonnull WPMediaPickerViewController *)picker {
     if ([self.delegate respondsToSelector:@selector(mediaPickerControllerWillBeginLoadingData:)]) {
         [self.delegate mediaPickerControllerWillBeginLoadingData:picker];

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -214,19 +214,6 @@ static NSString *const ArrowDown = @"\u25be";
     return [self.mediaPicker defaultPreviewViewControllerForAsset:asset];
 }
 
-// TODO: Decide if this should be here or not
-//- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldPresentPreviewController:(nonnull UIViewController *)previewViewController {
-//    if ([self.delegate respondsToSelector:@selector(mediaPickerController:shouldPresentPreviewController:)]) {
-//        [self.delegate mediaPickerController:picker shouldPresentPreviewController:previewViewController];
-//    }
-//}
-//
-//- (void)mediaPickerControllerShouldDismissPreviewController:(nonnull WPMediaPickerViewController *)picker {
-//    if ([self.delegate respondsToSelector:@selector(mediaPickerControllerShouldDismissPreviewController:)]) {
-//        [self.delegate mediaPickerControllerShouldDismissPreviewController:picker];
-//    }
-//}
-
 - (void)mediaPickerControllerWillBeginLoadingData:(nonnull WPMediaPickerViewController *)picker {
     if ([self.delegate respondsToSelector:@selector(mediaPickerControllerWillBeginLoadingData:)]) {
         [self.delegate mediaPickerControllerWillBeginLoadingData:picker];


### PR DESCRIPTION
This PR overrides the `WPInputMediaPickerViewController`'s trait collection to disable 3D Touch so preview can work properly when the picker is used in an `inputView`. 

In addition, when displaying the preview controller itself, we default to `self.viewControllerToUseToPresent.navigationController` instead of `self.navigationController` because `self.navigationController` will be nil when the picker as an input view.

![test](https://user-images.githubusercontent.com/154014/28973073-c6c1a618-78f7-11e7-96e5-d4f18b801a89.gif)

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/7632

To test:

1. Review previewing in the demo app's quick select assets field. Verify long pressing and preview display works on all devices...with or without 3D Touch.
2. Install WPiOS from the the [picker's test branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/inline-media-picker-updates). 
3. Using a debug build, test the inline picker. Verify long pressing and preview display works on all devices...with or without 3D Touch.

@frosty Could I bother you for a review? Thanks!!
