### PR TITLE
Updates inline picker thumbnail size and scroll direction

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -42,7 +42,8 @@
                      MediaPickerOptionsAllowMultipleSelection:@(YES),
                      MediaPickerOptionsPostProcessingStep:@(NO),
                      MediaPickerOptionsFilterType:@(WPMediaTypeImage | WPMediaTypeVideo),
-                     MediaPickerOptionsCustomPreview:@(NO)
+                     MediaPickerOptionsCustomPreview:@(NO),
+                     MediaPickerOptionsScrollInputPickerVertically:@(NO)
                      };
 
 }
@@ -132,6 +133,9 @@
 
 - (void)setupMediaKeyboardForInputField {
     self.mediaInputViewController = [[WPInputMediaPickerViewController alloc] init];
+    if ([self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue]) {
+        self.mediaInputViewController.scrollVertically = YES;
+    }
 
     [self addChildViewController:self.mediaInputViewController];
     _quickInputTextField.inputView = self.mediaInputViewController.view;

--- a/Example/WPMediaPicker/OptionsViewController.h
+++ b/Example/WPMediaPicker/OptionsViewController.h
@@ -7,6 +7,7 @@ extern NSString const *MediaPickerOptionsAllowMultipleSelection;
 extern NSString const *MediaPickerOptionsPostProcessingStep;
 extern NSString const *MediaPickerOptionsFilterType;
 extern NSString const *MediaPickerOptionsCustomPreview;
+extern NSString const *MediaPickerOptionsScrollInputPickerVertically;
 
 @class OptionsViewController;
 

--- a/Example/WPMediaPicker/OptionsViewController.m
+++ b/Example/WPMediaPicker/OptionsViewController.m
@@ -9,6 +9,7 @@ NSString const *MediaPickerOptionsAllowMultipleSelection = @"MediaPickerOptionsA
 NSString const *MediaPickerOptionsPostProcessingStep = @"MediaPickerOptionsPostProcessingStep";
 NSString const *MediaPickerOptionsFilterType = @"MediaPickerOptionsFilterType";
 NSString const *MediaPickerOptionsCustomPreview = @"MediaPickerOptionsCustomPreview";
+NSString const *MediaPickerOptionsScrollInputPickerVertically = @"MediaPickerOptionsScrollInputPickerVertically";
 
 typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellShowMostRecentFirst,
@@ -18,6 +19,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellPostProcessingStep,
     OptionsViewControllerCellMediaType,
     OptionsViewControllerCellCustomPreview,
+    OptionsViewControllerCellInputPickerScroll,
     OptionsViewControllerCellTotal
 };
 
@@ -30,6 +32,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
 @property (nonatomic, strong) UITableViewCell *postProcessingStepCell;
 @property (nonatomic, strong) UITableViewCell *filterMediaCell;
 @property (nonatomic, strong) UITableViewCell *customPreviewCell;
+@property (nonatomic, strong) UITableViewCell *scrollInputPickerCell;
 
 @end
 
@@ -86,6 +89,11 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     self.customPreviewCell.accessoryView = [[UISwitch alloc] init];
     ((UISwitch *)self.customPreviewCell.accessoryView).on = [self.options[MediaPickerOptionsCustomPreview] boolValue];
     self.customPreviewCell.textLabel.text = @"Use Custom Preview Controller";
+
+    self.scrollInputPickerCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    self.scrollInputPickerCell.accessoryView = [[UISwitch alloc] init];
+    ((UISwitch *)self.scrollInputPickerCell.accessoryView).on = [self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue];
+    self.scrollInputPickerCell.textLabel.text = @"Scroll Input Picker Vertically";
 }
 
 #pragma mark - Table view data source
@@ -124,6 +132,9 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
         case OptionsViewControllerCellCustomPreview:
             return self.customPreviewCell;
             break;
+        case OptionsViewControllerCellInputPickerScroll:
+            return self.scrollInputPickerCell;
+            break;
         default:
             break;
     }
@@ -150,6 +161,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
              MediaPickerOptionsPostProcessingStep:@(((UISwitch *)self.postProcessingStepCell.accessoryView).on),
              MediaPickerOptionsFilterType:@(filterType),
              MediaPickerOptionsCustomPreview:@(((UISwitch *)self.customPreviewCell.accessoryView).on),
+             MediaPickerOptionsScrollInputPickerVertically:@(((UISwitch *)self.scrollInputPickerCell.accessoryView).on),
              };
         
         [delegate optionsViewController:self changed:newOptions];

--- a/Pod/Classes/WPInputMediaPickerViewController.h
+++ b/Pod/Classes/WPInputMediaPickerViewController.h
@@ -40,4 +40,9 @@ The delegate for the WPMediaPickerViewController events
  */
 @property (nonatomic, readonly) UIToolbar * _Nonnull mediaToolbar;
 
+/**
+ If YES the picker will scroll media vertically. Defaults to NO (horizontal).
+ */
+@property (nonatomic, assign) BOOL scrollVertically;
+
 @end

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -1,6 +1,13 @@
 #import "WPInputMediaPickerViewController.h"
 #import "WPPHAssetDataSource.h"
 
+static CGFloat const IPhoneSELandscapeWidth = 568.0f;
+static CGFloat const IPhone7PortraitWidth = 375.0f;
+static CGFloat const IPhone7LandscapeWidth = 667.0f;
+static CGFloat const IPadPortraitWidth = 768.0f;
+static CGFloat const IPadLandscapeWidth = 1024.0f;
+static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
+
 @interface WPInputMediaPickerViewController()
 
 @property (nonatomic, strong) WPMediaPickerViewController *mediaPicker;
@@ -55,9 +62,6 @@
     self.mediaPicker.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:self.mediaPicker.view];
     [self.mediaPicker didMoveToParentViewController:self];
-    self.mediaPicker.collectionView.bounces = NO;
-    self.mediaPicker.collectionView.alwaysBounceHorizontal = NO;
-    self.mediaPicker.collectionView.alwaysBounceVertical = NO;
 
     self.mediaToolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 44)];
     self.mediaToolbar.items = @[
@@ -101,10 +105,14 @@
 
         layout.scrollDirection = UICollectionViewScrollDirectionVertical;
         layout.sectionInset = UIEdgeInsetsMake(2, 0, 0, 0);
+        self.mediaPicker.collectionView.alwaysBounceHorizontal = NO;
+        self.mediaPicker.collectionView.alwaysBounceVertical = YES;
     } else {
         photoSize = floorf((self.view.frame.size.height - photoSpacing) / 2.0);
         layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
         layout.sectionInset = UIEdgeInsetsMake(0, 5, 0, 5);
+        self.mediaPicker.collectionView.alwaysBounceHorizontal = YES;
+        self.mediaPicker.collectionView.alwaysBounceVertical = NO;
     }
 
     layout.itemSize = CGSizeMake(photoSize, photoSize);
@@ -125,16 +133,18 @@
 - (NSUInteger)numberOfPhotosPerRow:(CGFloat)frameWidth {
     NSUInteger numberOfPhotos = 3;
 
-    if (frameWidth >= 375 && frameWidth < 500) {
+    if (frameWidth >= IPhone7PortraitWidth && frameWidth < IPhoneSELandscapeWidth) {
         numberOfPhotos = 4;
-    } else if (frameWidth >= 500 && frameWidth < 667) {
+    } else if (frameWidth >= IPhoneSELandscapeWidth && frameWidth < IPhone7LandscapeWidth) {
         numberOfPhotos = 5;
-    } else if (frameWidth >= 667  && frameWidth < 768) {
+    } else if (frameWidth >= IPhone7LandscapeWidth && frameWidth < IPadPortraitWidth) {
         numberOfPhotos = 6;
-    } else if (frameWidth >= 768  && frameWidth < 1024) {
+    } else if (frameWidth >= IPadPortraitWidth && frameWidth < IPadLandscapeWidth) {
         numberOfPhotos = 7;
-    } else if (frameWidth >= 1024) {
+    } else if (frameWidth >= IPadLandscapeWidth && frameWidth < IPadPro12LandscapeWidth) {
         numberOfPhotos = 9;
+    } else if (frameWidth >= IPadPro12LandscapeWidth) {
+        numberOfPhotos = 12;
     }
 
     return numberOfPhotos;

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -71,28 +71,28 @@
 }
 
 - (void)configureCollectionView {
-    CGFloat frameHeightWidth = self.view.frame.size.width;
-    NSUInteger numberOfPhotosForLine = [self numberOfPhotosPerRow:frameHeightWidth];
+    CGFloat frameWidth = self.view.frame.size.width;
+    NSUInteger numberOfPhotosForLine = [self numberOfPhotosPerRow:frameWidth];
     CGFloat photoSpacing = 1.0f;
     CGFloat topInset = 5.0f;
     CGFloat bottomInset = 10.0f;
 
     CGFloat cellSize = [self.mediaPicker cellSizeForPhotosPerLineCount:numberOfPhotosForLine
                                                           photoSpacing:photoSpacing
-                                                            frameWidth:frameHeightWidth];
+                                                            frameWidth:frameWidth];
 
     // Check the actual width of the content based on the computed cell size
     // How many photos are we actually fitting per line?
     CGFloat totalSpacing = (numberOfPhotosForLine - 1) * photoSpacing;
-    numberOfPhotosForLine = floorf((frameHeightWidth - totalSpacing) / cellSize);
+    numberOfPhotosForLine = floorf((frameWidth - totalSpacing) / cellSize);
 
     CGFloat contentWidth = (numberOfPhotosForLine * cellSize) + totalSpacing;
 
     // If we have gaps in our layout, adjust to fit
-    if (contentWidth < frameHeightWidth) {
+    if (contentWidth < frameWidth) {
         cellSize = [self.mediaPicker cellSizeForPhotosPerLineCount:numberOfPhotosForLine
                                                       photoSpacing:photoSpacing
-                                                        frameWidth:frameHeightWidth];
+                                                        frameWidth:frameWidth];
     }
     
     // Init and configure collection view layout
@@ -121,8 +121,12 @@
         numberOfPhotos = 4;
     } else if (frameWidth >= 500 && frameWidth < 667) {
         numberOfPhotos = 5;
-    } else if (frameWidth >= 667) {
+    } else if (frameWidth >= 667  && frameWidth < 768) {
         numberOfPhotos = 6;
+    } else if (frameWidth >= 768  && frameWidth < 1024) {
+        numberOfPhotos = 7;
+    } else if (frameWidth >= 1024) {
+        numberOfPhotos = 9;
     }
 
     return numberOfPhotos;

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -35,7 +35,6 @@
     return self;
 }
 
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -72,16 +71,15 @@
 }
 
 - (void)configureCollectionView {
-    CGFloat numberOfPhotosForLine = 4;
+    CGFloat frameHeightWidth = self.view.frame.size.width;
+    NSUInteger numberOfPhotosForLine = [self numberOfPhotosPerRow:frameHeightWidth];
     CGFloat photoSpacing = 1.0f;
     CGFloat topInset = 5.0f;
     CGFloat bottomInset = 10.0f;
-    CGFloat frameHeightWidth = self.view.frame.size.width;
-    CGFloat minFrameWidth = MIN(frameHeightWidth, frameHeightWidth);
 
     CGFloat cellSize = [self.mediaPicker cellSizeForPhotosPerLineCount:numberOfPhotosForLine
                                                           photoSpacing:photoSpacing
-                                                            frameWidth:minFrameWidth];
+                                                            frameWidth:frameHeightWidth];
 
     // Check the actual width of the content based on the computed cell size
     // How many photos are we actually fitting per line?
@@ -109,6 +107,27 @@
     self.mediaPicker.collectionView.collectionViewLayout = layout;
 }
 
+/**
+ Returns the maximum number of photos to be used in a picker row given the provided frame width.
+ 
+ @param frameWidth Width size of the frame containing the picker
+
+ @return The number of photo cells to be used in a row. Defaults to 3.
+ */
+- (NSUInteger)numberOfPhotosPerRow:(CGFloat)frameWidth {
+    NSUInteger numberOfPhotos = 3;
+
+    if (frameWidth >= 375 && frameWidth < 500) {
+        numberOfPhotos = 4;
+    } else if (frameWidth >= 500 && frameWidth < 667) {
+        numberOfPhotos = 5;
+    } else if (frameWidth >= 667) {
+        numberOfPhotos = 6;
+    }
+
+    return numberOfPhotos;
+}
+
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
     [super traitCollectionDidChange:previousTraitCollection];
@@ -124,6 +143,8 @@
     [self setOverrideTraitCollection:[UITraitCollection traitCollectionWithTraitsFromCollections:@[self.traitCollection, traits]] forChildViewController:self.mediaPicker];
 }
 
+#pragma mark - WPMediaCollectionDataSource
+
 - (void)setDataSource:(id<WPMediaCollectionDataSource>)dataSource {
     self.mediaPicker.dataSource = dataSource;
 }
@@ -131,6 +152,8 @@
 - (id<WPMediaCollectionDataSource>)dataSource {
     return self.mediaPicker.dataSource;
 }
+
+#pragma mark - WPMediaPickerViewControllerDelegate
 
 - (void)setMediaPickerDelegate:(id<WPMediaPickerViewControllerDelegate>)mediaPickerDelegate {
     self.mediaPicker.mediaPickerDelegate = mediaPickerDelegate;

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -56,7 +56,7 @@
     self.mediaPicker.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:self.mediaPicker.view];
     [self.mediaPicker didMoveToParentViewController:self];
-    self.mediaPicker.collectionView.alwaysBounceVertical = NO;
+    self.mediaPicker.collectionView.alwaysBounceHorizontal = NO;
 
     self.mediaToolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 44)];
     self.mediaToolbar.items = @[
@@ -68,19 +68,45 @@
 
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
+    [self configureCollectionView];
+}
 
-    CGFloat spacing = 1.0f;
-    CGFloat size = floorf((self.view.frame.size.height - spacing) / 2.0);
-    self.mediaPicker.options.cameraPreviewSize = CGSizeMake(1.5*size, 1.5*size);
+- (void)configureCollectionView {
+    CGFloat numberOfPhotosForLine = 4;
+    CGFloat photoSpacing = 1.0f;
+    CGFloat topInset = 5.0f;
+    CGFloat bottomInset = 10.0f;
+    CGFloat frameHeightWidth = self.view.frame.size.width;
+    CGFloat minFrameWidth = MIN(frameHeightWidth, frameHeightWidth);
+
+    CGFloat cellSize = [self.mediaPicker cellSizeForPhotosPerLineCount:numberOfPhotosForLine
+                                                          photoSpacing:photoSpacing
+                                                            frameWidth:minFrameWidth];
+
+    // Check the actual width of the content based on the computed cell size
+    // How many photos are we actually fitting per line?
+    CGFloat totalSpacing = (numberOfPhotosForLine - 1) * photoSpacing;
+    numberOfPhotosForLine = floorf((frameHeightWidth - totalSpacing) / cellSize);
+
+    CGFloat contentWidth = (numberOfPhotosForLine * cellSize) + totalSpacing;
+
+    // If we have gaps in our layout, adjust to fit
+    if (contentWidth < frameHeightWidth) {
+        cellSize = [self.mediaPicker cellSizeForPhotosPerLineCount:numberOfPhotosForLine
+                                                      photoSpacing:photoSpacing
+                                                        frameWidth:frameHeightWidth];
+    }
+    
+    // Init and configure collection view layout
     UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-    layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
-    layout.itemSize = CGSizeMake(size, size);
-    layout.minimumLineSpacing = spacing;
-    layout.minimumInteritemSpacing = spacing;
-    layout.sectionInset = UIEdgeInsetsMake(0, 5, 0, 10);
+    layout.scrollDirection = UICollectionViewScrollDirectionVertical;
+    layout.itemSize = CGSizeMake(cellSize, cellSize);
+    layout.minimumInteritemSpacing = photoSpacing;
+    layout.minimumLineSpacing = photoSpacing;
+    layout.sectionInset = UIEdgeInsetsMake(topInset, 0, bottomInset, 0);
 
+    self.mediaPicker.options.cameraPreviewSize = CGSizeMake(1.5*cellSize, 1.5*cellSize);
     self.mediaPicker.collectionView.collectionViewLayout = layout;
-
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -186,5 +186,15 @@
  */
 - (nonnull UIViewController *)defaultPreviewViewControllerForAsset:(nonnull id <WPMediaAsset>)asset;
 
+/**
+ Return the default preview view controller to use to preview assets
+
+ @param photosPerLine The number of desired photos per line
+ @param photoSpacing The amount of space inbetween photos
+ @param frameWidth The width of the frame which contains the photo cells
+ @return A CGFloat representing the height/width of the suggested cell size
+ */
+- (CGFloat)cellSizeForPhotosPerLineCount:(NSUInteger)photosPerLine photoSpacing:(CGFloat)photoSpacing frameWidth:(CGFloat)frameWidth;
+
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -187,10 +187,11 @@
 - (nonnull UIViewController *)defaultPreviewViewControllerForAsset:(nonnull id <WPMediaAsset>)asset;
 
 /**
- Return the default preview view controller to use to preview assets
+ Calculates the appropriate cell height/width given the desired number of cells per line, desired space
+ between cells, and total width of the frame containing the cells.
 
  @param photosPerLine The number of desired photos per line
- @param photoSpacing The amount of space inbetween photos
+ @param photoSpacing The amount of space in between photos
  @param frameWidth The width of the frame which contains the photo cells
  @return A CGFloat representing the height/width of the suggested cell size
  */


### PR DESCRIPTION
This PR:

1. Changes the scroll direction of the inline picker to vertical.
2. Adjusts the number of image cells per row based on the width of the frame which contains the input picker. Devices: 
  * SE = 3-wide portrait / 5-wide landscape
  * 7/7+ = 4-wide portrait / 6-wide landscape
  * iPad @ 768 = 7-wide
  * iPad @ 1024 = 9-wide

<img width="538" alt="napkin 47 08-07-17 4 45 35 pm" src="https://user-images.githubusercontent.com/154014/29047746-ce580258-7b92-11e7-8159-388e55e3b1c0.png">
<img width="601" alt="napkin 47 08-07-17 4 46 40 pm" src="https://user-images.githubusercontent.com/154014/29047750-d19e6998-7b92-11e7-98a0-dbd4609796ee.png">

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/7630
Fixes #196 

**To test:** 
1. On a variety of devices run the picker demo app, verify the picker grid scrolls vertically and the correct number of images are displayed in each orientation.
2. Download and run [the test branch for WPiOS](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/inline-media-picker-updates). Verify the picker grid scrolls vertically and the correct number of images are displayed in each orientation.

@kwonye would you be able to give this a quick 👀 ?

cc/ @iamthomasbishop 