### PR TITLE
Expose `showCapture` functionality to media picker and input picker

### DIFF
--- a/Pod/Classes/WPInputMediaPickerViewController.h
+++ b/Pod/Classes/WPInputMediaPickerViewController.h
@@ -45,4 +45,9 @@ The delegate for the WPMediaPickerViewController events
  */
 @property (nonatomic, assign) BOOL scrollVertically;
 
+/**
+ * Presents the system image / video capture view controller, presented from `viewControllerToUseToPresent`.
+ */
+- (void)showCapture;
+
 @end

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -200,5 +200,9 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
     }
 }
 
+- (void)showCapture
+{
+    [self.mediaPicker showCapture];
+}
 
 @end

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -168,6 +168,11 @@
 - (void)clearSelectedAssets:(BOOL)animated;
 
 /**
+ * Presents the system image / video capture view controller, presented from `viewControllerToUseToPresent`.
+ */
+- (void)showCapture;
+
+/**
  View controller to use when picker needs to present another controller. By default this is set to self.
  @note If the picker is being used within an input view, it's important to set this value to something besides the picker itself.
  */


### PR DESCRIPTION
This PR exposes the `showCapture` method in the interface of media picker and the input picker, so we can present the capture UI directly from the new inline picker format bar in WPiOS.

Not much to check here!

Needs review: @SergioEstevao 