### PR TITLE
Fix some capture cell issues.

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -132,7 +132,11 @@
 }
 
 - (void)setupMediaKeyboardForInputField {
-    self.mediaInputViewController = [[WPInputMediaPickerViewController alloc] init];
+    if (self.mediaInputViewController) {
+        [self.mediaInputViewController removeFromParentViewController];
+    } else {
+        self.mediaInputViewController = [[WPInputMediaPickerViewController alloc] init];
+    }
     if ([self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue]) {
         self.mediaInputViewController.scrollVertically = YES;
     }

--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -26,11 +26,11 @@
 {
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceOrientationDidChange:) name:UIDeviceOrientationDidChangeNotification object:nil];
-
+    self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.backgroundColor = [UIColor blackColor];
     _sessionQueue = dispatch_queue_create("org.wordpress.WPMediaCapturePreviewCollectionView", DISPATCH_QUEUE_SERIAL);
     _previewView = [[UIView alloc] initWithFrame:self.bounds];
-    _previewView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;    
+    _previewView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self addSubview:_previewView];
     
     UIImage *cameraImage = [[WPMediaPickerResources imageNamed:@"gridicons-camera-large" withExtension:@"png"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -49,6 +49,7 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
+    self.previewView.frame = self.bounds;
     self.captureVideoPreviewLayer.frame = self.previewView.bounds;
 }
 

--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -30,7 +30,7 @@
     self.backgroundColor = [UIColor blackColor];
     _sessionQueue = dispatch_queue_create("org.wordpress.WPMediaCapturePreviewCollectionView", DISPATCH_QUEUE_SERIAL);
     _previewView = [[UIView alloc] initWithFrame:self.bounds];
-    _previewView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _previewView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;    
     [self addSubview:_previewView];
     
     UIImage *cameraImage = [[WPMediaPickerResources imageNamed:@"gridicons-camera-large" withExtension:@"png"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -101,10 +101,11 @@
         }
         if (!self.session.isRunning ||  !self.captureVideoPreviewLayer.connection.enabled){
             [self.session startRunning];
+            AVCaptureVideoPreviewLayer * newLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (!self.captureVideoPreviewLayer || !self.captureVideoPreviewLayer.connection.enabled) {
                     [self.captureVideoPreviewLayer removeFromSuperlayer];
-                    self.captureVideoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
+                    self.captureVideoPreviewLayer = newLayer;
                     CALayer *viewLayer = self.previewView.layer;
                     self.captureVideoPreviewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
                     self.captureVideoPreviewLayer.frame = viewLayer.bounds;


### PR DESCRIPTION
The capture cell was sometimes getting the main thread stuck when returning from a capture.

This PR improves the performance of capture by creating the video layer on the background capture session thread.

To test:
 - Start the demo app on a device
 - Tap on the live preview cell
 - Capture an photo
 - Accept
 - Return to the picker and see if nothing get's stuck and the live preview cell resumes normally.

