### PR TITLE
Issue/fix header size on start

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -137,9 +137,7 @@
     } else {
         self.mediaInputViewController = [[WPInputMediaPickerViewController alloc] init];
     }
-    if ([self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue]) {
-        self.mediaInputViewController.scrollVertically = YES;
-    }
+    self.mediaInputViewController.scrollVertically = [self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue];
 
     [self addChildViewController:self.mediaInputViewController];
     _quickInputTextField.inputView = self.mediaInputViewController.view;

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -44,8 +44,7 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 
 - (void)viewDidLoad
 {
-    [super viewDidLoad];
-    self.view.backgroundColor = [UIColor redColor];
+    [super viewDidLoad];    
     [self setupMediaPickerViewController];
 }
 

--- a/Pod/Classes/WPMediaCapturePreviewCollectionView.m
+++ b/Pod/Classes/WPMediaCapturePreviewCollectionView.m
@@ -102,18 +102,18 @@
         }
         if (!self.session.isRunning ||  !self.captureVideoPreviewLayer.connection.enabled){
             [self.session startRunning];
-            AVCaptureVideoPreviewLayer * newLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (!self.captureVideoPreviewLayer || !self.captureVideoPreviewLayer.connection.enabled) {
-                    [self.captureVideoPreviewLayer removeFromSuperlayer];
-                    self.captureVideoPreviewLayer = newLayer;
-                    CALayer *viewLayer = self.previewView.layer;
-                    self.captureVideoPreviewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
-                    self.captureVideoPreviewLayer.frame = viewLayer.bounds;
-                    self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
-                    [viewLayer addSublayer:_captureVideoPreviewLayer];
-                }
-            });
+            if (!self.captureVideoPreviewLayer || !self.captureVideoPreviewLayer.connection.enabled) {
+                AVCaptureVideoPreviewLayer * newLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                        [self.captureVideoPreviewLayer removeFromSuperlayer];
+                        self.captureVideoPreviewLayer = newLayer;
+                        CALayer *viewLayer = self.previewView.layer;
+                        self.captureVideoPreviewLayer.frame = viewLayer.bounds;
+                        self.captureVideoPreviewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+                        self.captureVideoPreviewLayer.connection.videoOrientation = [self videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
+                        [viewLayer addSublayer:self.captureVideoPreviewLayer];
+                });
+            }
         }
     });
 }

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -279,13 +279,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (void)refreshDataAnimated:(BOOL)animated
 {
-    if (self.refreshGroupFirstTime) {
-        if (![self.refreshControl isRefreshing]) {
-            [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length]) animated:NO];
-            [self.collectionView setContentOffset:CGPointMake(0, - [[self topLayoutGuide] length] - (self.refreshControl.frame.size.height)) animated:animated];
-            [self.refreshControl beginRefreshing];
-        }        
-    }
+    [self.refreshControl beginRefreshing];
     self.collectionView.allowsSelection = NO;
     self.collectionView.allowsMultipleSelection = NO;
     self.collectionView.scrollEnabled = NO;


### PR DESCRIPTION
When opening the inputPicker for the first time on the demo and the live preview cell was active, the cell got the wrong size. After some testing I found out that we had some code on the refreshing of the picker that was causing the cell to get the wrong size.

To test:
 - Start the demo app.
 - Tap on the text field.
 - See if the live cell has the correct size.

Note: I think this didn't happen before the performance improvements because it took so much time to display the album the header cell got the correct size meanwhile.