### PR TITLE
If the view is not loaded yet we don’t need to force a refresh.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -774,11 +774,12 @@ referenceSizeForFooterInSection:(NSInteger)section
     if (group == [self.dataSource selectedGroup]){
         return;
     }
-
-    self.refreshGroupFirstTime = YES;
-    [self.collectionView reloadData];
     [self.dataSource setSelectedGroup:group];
-    [self refreshData];
+    if (self.isViewLoaded) {
+        self.refreshGroupFirstTime = YES;
+        [self.collectionView reloadData];
+        [self refreshData];
+    }
 }
 
 #pragma mark - Long Press Handling


### PR DESCRIPTION
This PR implement a super small fix to avoid a double refresh when setting the group the first time.

To test:
 - Start the demo app
 - Open the full screen picker
 - Check if opening albums work ok.