### PR TITLE
Implement hiding of selection indicator.

### DIFF
--- a/Pod/Classes/WPMediaCollectionViewCell.h
+++ b/Pod/Classes/WPMediaCollectionViewCell.h
@@ -10,4 +10,6 @@
 
 @property (nonatomic, strong) UIColor *positionLabelUnselectedTintColor UI_APPEARANCE_SELECTOR;
 
+@property (nonatomic, assign) BOOL hiddenSelectionIndicator;
+
 @end

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -354,7 +354,8 @@ static const CGFloat LabelRegularFontSize = 13;
 - (void)updatePositionLabelToSelectedState:(BOOL)selected
 {
     _positionLabel.hidden = _hiddenSelectionIndicator;
-    _positionLabelShadowView.hidden = _hiddenSelectionIndicator;    
+    _positionLabelShadowView.hidden = _hiddenSelectionIndicator;
+    _selectionFrame.hidden = _hiddenSelectionIndicator;
 
     if (selected) {
         _positionLabel.backgroundColor = [self tintColor];

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -84,6 +84,8 @@ static const CGFloat LabelRegularFontSize = 13;
     CGFloat labelMargin = 10.0;
     CGFloat labelSize = 20;
 
+    _hiddenSelectionIndicator = NO;
+    
     _positionLabelUnselectedTintColor = [UIColor colorWithRed:198.0/255.0 green:198.0/255.0 blue:198.0/255.0 alpha:0.7];
     _positionLabel = [[UILabel alloc] initWithFrame:CGRectMake(labelMargin, self.contentView.frame.size.height - (labelSize + labelMargin), labelSize, labelSize)];
     _positionLabel.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
@@ -351,6 +353,9 @@ static const CGFloat LabelRegularFontSize = 13;
 
 - (void)updatePositionLabelToSelectedState:(BOOL)selected
 {
+    _positionLabel.hidden = _hiddenSelectionIndicator;
+    _positionLabelShadowView.hidden = _hiddenSelectionIndicator;    
+
     if (selected) {
         _positionLabel.backgroundColor = [self tintColor];
         _positionLabel.layer.borderColor = [self tintColor].CGColor;
@@ -361,7 +366,11 @@ static const CGFloat LabelRegularFontSize = 13;
         _positionLabel.layer.borderColor = [UIColor whiteColor].CGColor;
         _positionLabelShadowView.hidden = YES;
     }
+}
 
+- (void)setHiddenSelectionIndicator:(BOOL)hiddenSelectionIndicator {
+    _hiddenSelectionIndicator = hiddenSelectionIndicator;
+    [self updatePositionLabelToSelectedState:self.selected];
 }
 
 @end

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -112,13 +112,20 @@ static CGFloat SelectAnimationTime = 0.2;
 - (void)setOptions:(WPMediaPickerOptions *)options {
     WPMediaPickerOptions *originalOptions = _options;
     _options = [options copy];
-    BOOL refreshNeeded = (originalOptions.filter != options.filter) | (originalOptions.showMostRecentFirst != options.showMostRecentFirst) | (originalOptions.allowCaptureOfMedia != options.allowCaptureOfMedia);
+    BOOL refreshNeeded = (originalOptions.filter != options.filter) ||
+                         (originalOptions.showMostRecentFirst != options.showMostRecentFirst) ||
+                         (originalOptions.allowCaptureOfMedia != options.allowCaptureOfMedia);
     if (self.viewLoaded) {
         [self.dataSource setMediaTypeFilter:options.filter];
         [self.dataSource setAscendingOrdering:!options.showMostRecentFirst];
         self.collectionView.allowsMultipleSelection = options.allowMultipleSelection;
         if (refreshNeeded) {
             [self refreshDataAnimated:NO];
+        } else {
+            // if just the selection mode changed we just need to reload the collection view not all the data.
+            if (originalOptions.allowMultipleSelection != options.allowMultipleSelection) {
+                [self.collectionView reloadData];
+            }
         }
     }
 }
@@ -442,6 +449,7 @@ static CGFloat SelectAnimationTime = 0.2;
     // Configure the cell
     cell.asset = asset;
     NSUInteger position = [self positionOfAssetInSelection:asset];
+    cell.hiddenSelectionIndicator = !self.options.allowMultipleSelection;
     if (position != NSNotFound) {
         [self.collectionView selectItemAtIndexPath:indexPath animated:NO scrollPosition:UICollectionViewScrollPositionNone];
         if (self.options.allowMultipleSelection) {


### PR DESCRIPTION
Fixes #216 

To test:
 - Start the demo app
 - Go to the options and disable allow multiple selection
 - Go inside the pickers and see that the selection circle doesn't show up
 - Go to option agains and enable multiple selection
 - Open picker again and see if the circle shows up
