### PR TITLE
Extract capture presentation

### DIFF
--- a/Pod/Classes/WPMediaCapturePresenter.h
+++ b/Pod/Classes/WPMediaCapturePresenter.h
@@ -1,0 +1,24 @@
+@import UIKit;
+#import "WPMediaCollectionDataSource.h"
+
+@interface WPMediaCapturePresenter : NSObject
+
+/// Only image and video types are supported
+@property (nonatomic) WPMediaType mediaType;
+
+/// Present front camera if available
+@property (nonatomic) BOOL preferFrontCamera;
+
+/// Called when the capture view has been dismissed.
+/// mediaInfo will be populated if an image / video was captured.
+@property (nonatomic, copy, nullable) void (^completionBlock)(NSDictionary * _Nullable mediaInfo);
+
++ (BOOL)isCaptureAvailable;
+
+/// @param viewController The view controller to present the capture view from.
+- (instancetype _Nonnull)initWithPresentingViewController:(UIViewController *_Nonnull)viewController;
+
+/// Present the capture interface
+- (void)presentCapture;
+
+@end

--- a/Pod/Classes/WPMediaCapturePresenter.m
+++ b/Pod/Classes/WPMediaCapturePresenter.m
@@ -1,0 +1,130 @@
+#import "WPMediaCapturePresenter.h"
+#import "WPMediaCollectionDataSource.h"
+
+@import MobileCoreServices;
+@import AVFoundation;
+
+@interface WPMediaCapturePresenter () <UINavigationControllerDelegate, UIImagePickerControllerDelegate>
+@property (nonatomic, strong, nullable) UIViewController *presentingViewController;
+@end
+
+@implementation WPMediaCapturePresenter
+
++ (BOOL)isCaptureAvailable
+{
+    return [UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera];
+}
+
+- (instancetype)initWithPresentingViewController:(UIViewController *)viewController
+{
+    if (self = [super init]) {
+        _presentingViewController = viewController;
+    }
+
+    return self;
+}
+
+- (void)presentCapture
+{
+    NSString *avMediaType = AVMediaTypeVideo;
+    AVAuthorizationStatus authorizationStatus = [AVCaptureDevice authorizationStatusForMediaType:avMediaType];
+    if (authorizationStatus == AVAuthorizationStatusAuthorized) {
+        [self presentCaptureViewController];
+        return;
+    }
+
+    if (authorizationStatus == AVAuthorizationStatusNotDetermined) {
+        [AVCaptureDevice requestAccessForMediaType:avMediaType completionHandler:^(BOOL granted) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (!granted)
+                {
+                    [self presentPermissionAlert];
+                    return;
+                }
+                [self presentCaptureViewController];
+            });
+        }];
+        return;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self presentPermissionAlert];
+    });
+}
+
+- (void)presentPermissionAlert
+{
+    NSString *title = NSLocalizedString(@"Media Capture", @"Title for alert when access to media capture is not granted");
+    NSString *message =NSLocalizedString(@"This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this.", @"");
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", "Confirmation of action") style:UIAlertActionStyleCancel handler:nil];
+    [alertController addAction:okAction];
+
+    NSString *otherButtonTitle = NSLocalizedString(@"Open Settings", @"Go to the settings app");
+    UIAlertAction *otherAction = [UIAlertAction actionWithTitle:otherButtonTitle
+                                                          style:UIAlertActionStyleDefault
+                                                        handler:^(UIAlertAction *action) {
+                                                            NSURL *settingsURL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+                                                            [[UIApplication sharedApplication] openURL:settingsURL];
+                                                        }];
+    [alertController addAction:otherAction];
+    
+    [self.presentingViewController presentViewController:alertController animated:YES completion:nil];
+}
+
+- (void)presentCaptureViewController
+{
+    UIImagePickerController *imagePickerController = [[UIImagePickerController alloc] init];
+    NSMutableSet *mediaTypes = [NSMutableSet setWithArray:[UIImagePickerController availableMediaTypesForSourceType:
+                                                           UIImagePickerControllerSourceTypeCamera]];
+    NSMutableSet *mediaDesired = [NSMutableSet new];
+    if (self.mediaType & WPMediaTypeImage) {
+        [mediaDesired addObject:(__bridge NSString *)kUTTypeImage];
+    }
+    if (self.mediaType & WPMediaTypeVideo) {
+        [mediaDesired addObject:(__bridge NSString *)kUTTypeMovie];
+
+    }
+    if (mediaDesired.count > 0){
+        [mediaTypes intersectSet:mediaDesired];
+    }
+
+    imagePickerController.mediaTypes = [mediaTypes allObjects];
+    imagePickerController.delegate = self;
+    imagePickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+    imagePickerController.cameraDevice = [self cameraDevice];
+    imagePickerController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+    imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+    [self.presentingViewController presentViewController:imagePickerController animated:YES completion:nil];
+}
+
+- (UIImagePickerControllerCameraDevice)cameraDevice
+{
+    if (self.preferFrontCamera && [UIImagePickerController isCameraDeviceAvailable:UIImagePickerControllerCameraDeviceFront]) {
+        return UIImagePickerControllerCameraDeviceFront;
+    } else {
+        return UIImagePickerControllerCameraDeviceRear;
+    }
+}
+
+#pragma mark - UIImagePickerControllerDelegate
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
+{
+    [picker dismissViewControllerAnimated:YES completion:^{
+        if (self.completionBlock) {
+            self.completionBlock(info);
+        }
+    }];
+}
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
+{
+    [picker dismissViewControllerAnimated:YES completion:^{
+        if (self.completionBlock) {
+            self.completionBlock(nil);
+        }
+    }];
+}
+
+@end


### PR DESCRIPTION
This PR extracts the functionality for displaying the image capture interface from the media picker itself. This makes it easier to present it by itself from other places – in particular, from a new option we'll be adding to the hybrid editor in WPiOS.

To test:

* Build and run the demo app and check that image capture still works as expected.