### PR TITLE
Fixes content offset issue when the inline picker is set to vertical

### DIFF
--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -59,6 +59,7 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
     
     self.mediaPicker.view.frame = self.view.bounds;
     self.mediaPicker.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.mediaPicker.collectionView.collectionViewLayout = [[UICollectionViewFlowLayout alloc] init];
     [self.view addSubview:self.mediaPicker.view];
     [self.mediaPicker didMoveToParentViewController:self];
 
@@ -78,7 +79,7 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 - (void)configureCollectionView {
     CGFloat photoSpacing = 1.0f;
     CGFloat photoSize;
-    UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.mediaPicker.collectionView.collectionViewLayout;
 
     if (self.scrollVertically) {
         CGFloat frameWidth = self.view.frame.size.width;
@@ -118,7 +119,6 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
     layout.minimumLineSpacing = photoSpacing;
     layout.minimumInteritemSpacing = photoSpacing;
     self.mediaPicker.options.cameraPreviewSize = CGSizeMake(1.5*photoSize, 1.5*photoSize);
-    self.mediaPicker.collectionView.collectionViewLayout = layout;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/7754

<img width="383" alt="napkin 47 09-06-17 2 50 30 pm" src="https://user-images.githubusercontent.com/154014/30131970-5d7d4d56-9314-11e7-97c2-5810df15fbab.png">

This PR fixes an issue where the collection view's content offset is modified because  `viewDidLayoutSubviews` is called multiple times before the photo grid is displayed. Now, we only create the flow layout once and then modify it accordingly in `configureCollectionView`.

H/T: [This guy](http://samwize.com/2016/04/04/the-bug-to-do-with-uicollectionview-content-offset/#comment-2896704421). 

### To test

In the media picker demo:
1. Set the input picker to scroll vertically (in the options)
2. Tap on the media picker quick select field — verify the content is not cut off.
3. Long press on any picture to preview and then tap cancel on the preview VC.
4. When the input picker appears again, verify the content is not cut off.

Test in WPiOS using [this branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/7754-media-picker-scroll-fix):
1. Open the Aztec editor to start a new post.
2. Select the + to open the inline media picker. Note that it loads as expected (at the very top of the list of device photos, starting with most recent).
3. Select a different media source (device photo library, camera, or WordPress media library).
4. Cancel to go back to the inline picker.
5. Verify the top row is not cut off (as described in the original bug).

Repeat a few times in WPiOS, however, try scrolling to random points in the inline picker before choosing a different media source. After canceling, verify the input picker returns to the exact same scroll point.

@SergioEstevao would you mind taking a quick look?