### PR TITLE
Refactor layout code to be all inside WPMediaPickerViewController.

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -43,7 +43,7 @@
                      MediaPickerOptionsPostProcessingStep:@(NO),
                      MediaPickerOptionsFilterType:@(WPMediaTypeImage | WPMediaTypeVideo),
                      MediaPickerOptionsCustomPreview:@(NO),
-                     MediaPickerOptionsScrollInputPickerVertically:@(NO)
+                     MediaPickerOptionsScrollInputPickerVertically:@(YES)
                      };
 
 }
@@ -138,8 +138,7 @@
         [self.mediaInputViewController didMoveToParentViewController:nil];
     } else {
         self.mediaInputViewController = [[WPInputMediaPickerViewController alloc] init];
-    }
-    self.mediaInputViewController.scrollVertically = [self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue];
+    }    
 
     [self addChildViewController:self.mediaInputViewController];
     _quickInputTextField.inputView = self.mediaInputViewController.view;
@@ -230,6 +229,7 @@
     options.preferFrontCamera = [self.options[MediaPickerOptionsPreferFrontCamera] boolValue];
     options.allowMultipleSelection = [self.options[MediaPickerOptionsAllowMultipleSelection] boolValue];
     options.filter = [self.options[MediaPickerOptionsFilterType] intValue];
+    options.scrollVertically = [self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue];
     return options;
 }
 

--- a/Pod/Classes/WPInputMediaPickerViewController.h
+++ b/Pod/Classes/WPInputMediaPickerViewController.h
@@ -41,11 +41,6 @@ The delegate for the WPMediaPickerViewController events
 @property (nonatomic, readonly, nonnull) UIToolbar *mediaToolbar;
 
 /**
- If YES the picker will scroll media vertically. Defaults to NO (horizontal).
- */
-@property (nonatomic, assign) BOOL scrollVertically;
-
-/**
  * Presents the system image / video capture view controller, presented from `viewControllerToUseToPresent`.
  */
 - (void)showCapture;

--- a/Pod/Classes/WPInputMediaPickerViewController.m
+++ b/Pod/Classes/WPInputMediaPickerViewController.m
@@ -1,13 +1,6 @@
 #import "WPInputMediaPickerViewController.h"
 #import "WPPHAssetDataSource.h"
 
-static CGFloat const IPhoneSELandscapeWidth = 568.0f;
-static CGFloat const IPhone7PortraitWidth = 375.0f;
-static CGFloat const IPhone7LandscapeWidth = 667.0f;
-static CGFloat const IPadPortraitWidth = 768.0f;
-static CGFloat const IPadLandscapeWidth = 1024.0f;
-static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
-
 @interface WPInputMediaPickerViewController()
 
 @property (nonatomic, strong) WPMediaPickerViewController *mediaPicker;
@@ -58,8 +51,7 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
     [self overridePickerTraits];
     
     self.mediaPicker.view.frame = self.view.bounds;
-    self.mediaPicker.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.mediaPicker.collectionView.collectionViewLayout = [[UICollectionViewFlowLayout alloc] init];
+    self.mediaPicker.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;    
     [self.view addSubview:self.mediaPicker.view];
     [self.mediaPicker didMoveToParentViewController:self];
 
@@ -73,85 +65,6 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
-    [self configureCollectionView];
-}
-
-- (void)configureCollectionView {
-    CGFloat photoSpacing = 1.0f;
-    CGFloat photoSize;
-    CGSize cameraPreviewSize;
-    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.mediaPicker.collectionView.collectionViewLayout;
-    if (self.scrollVertically) {
-        CGFloat frameWidth = self.view.frame.size.width;
-        NSUInteger numberOfPhotosForLine = [self numberOfPhotosPerRow:frameWidth];
-
-        photoSize = [self.mediaPicker cellSizeForPhotosPerLineCount:numberOfPhotosForLine
-                                                       photoSpacing:photoSpacing
-                                                         frameWidth:frameWidth];
-
-        // Check the actual width of the content based on the computed cell size
-        // How many photos are we actually fitting per line?
-        CGFloat totalSpacing = (numberOfPhotosForLine - 1) * photoSpacing;
-        numberOfPhotosForLine = floorf((frameWidth - totalSpacing) / photoSize);
-
-        CGFloat contentWidth = (numberOfPhotosForLine * photoSize) + totalSpacing;
-
-        // If we have gaps in our layout, adjust to fit
-        if (contentWidth < frameWidth) {
-            photoSize = [self.mediaPicker cellSizeForPhotosPerLineCount:numberOfPhotosForLine
-                                                           photoSpacing:photoSpacing
-                                                             frameWidth:frameWidth];
-        }
-
-        layout.scrollDirection = UICollectionViewScrollDirectionVertical;
-        layout.sectionInset = UIEdgeInsetsMake(2, 0, 0, 0);
-        self.mediaPicker.collectionView.alwaysBounceHorizontal = NO;
-        self.mediaPicker.collectionView.alwaysBounceVertical = YES;
-        cameraPreviewSize = CGSizeMake(photoSize, photoSize);
-    } else {
-        photoSize = floorf((self.view.frame.size.height - photoSpacing) / 2.0);
-        layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
-        layout.sectionInset = UIEdgeInsetsMake(0, 5, 0, 5);
-        self.mediaPicker.collectionView.alwaysBounceHorizontal = YES;
-        self.mediaPicker.collectionView.alwaysBounceVertical = NO;
-        cameraPreviewSize = CGSizeMake(1.5*photoSize, 1.5*photoSize);
-    }
-
-    layout.itemSize = CGSizeMake(photoSize, photoSize);
-    layout.minimumLineSpacing = photoSpacing;
-    layout.minimumInteritemSpacing = photoSpacing;    
-    WPMediaPickerOptions *options = [self.mediaPicker options];
-    options.cameraPreviewSize = cameraPreviewSize;
-    [self.mediaPicker setOptions:options];
-    [layout invalidateLayout];
-}
-
-/**
- Given the provided frame width, this method returns a progressively increasing number of photos 
- to be used in a picker row.
- 
- @param frameWidth Width of the frame containing the picker
-
- @return The number of photo cells to be used in a row. Defaults to 3.
- */
-- (NSUInteger)numberOfPhotosPerRow:(CGFloat)frameWidth {
-    NSUInteger numberOfPhotos = 3;
-
-    if (frameWidth >= IPhone7PortraitWidth && frameWidth < IPhoneSELandscapeWidth) {
-        numberOfPhotos = 4;
-    } else if (frameWidth >= IPhoneSELandscapeWidth && frameWidth < IPhone7LandscapeWidth) {
-        numberOfPhotos = 5;
-    } else if (frameWidth >= IPhone7LandscapeWidth && frameWidth < IPadPortraitWidth) {
-        numberOfPhotos = 6;
-    } else if (frameWidth >= IPadPortraitWidth && frameWidth < IPadLandscapeWidth) {
-        numberOfPhotos = 7;
-    } else if (frameWidth >= IPadLandscapeWidth && frameWidth < IPadPro12LandscapeWidth) {
-        numberOfPhotos = 9;
-    } else if (frameWidth >= IPadPro12LandscapeWidth) {
-        numberOfPhotos = 12;
-    }
-
-    return numberOfPhotos;
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/Pod/Classes/WPMediaPickerOptions.h
+++ b/Pod/Classes/WPMediaPickerOptions.h
@@ -29,8 +29,8 @@
 @property (nonatomic, assign) BOOL allowMultipleSelection;
 
 /**
- The size of the camera preview cell
+ If YES the picker will scroll media vertically. Defaults to YES (vertical).
  */
-@property (nonatomic, assign) CGSize cameraPreviewSize;
+@property (nonatomic, assign) BOOL scrollVertically;
 
 @end

--- a/Pod/Classes/WPMediaPickerOptions.m
+++ b/Pod/Classes/WPMediaPickerOptions.m
@@ -3,8 +3,6 @@
 
 @implementation WPMediaPickerOptions
 
-static CGSize CameraPreviewSize =  {88.0, 88.0};
-
 - (instancetype)init {
     self = [super init];
     if (self) {
@@ -12,8 +10,8 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
         _preferFrontCamera = NO;
         _showMostRecentFirst = NO;
         _filter = WPMediaTypeVideo | WPMediaTypeImage;
-        _cameraPreviewSize = CameraPreviewSize;
         _allowMultipleSelection = YES;
+        _scrollVertically = YES;
     }
     return self;
 }
@@ -24,8 +22,8 @@ static CGSize CameraPreviewSize =  {88.0, 88.0};
     options.preferFrontCamera = self.preferFrontCamera;
     options.showMostRecentFirst = self.showMostRecentFirst;
     options.filter = self.filter;
-    options.cameraPreviewSize = self.cameraPreviewSize;
     options.allowMultipleSelection = self.allowMultipleSelection;
+    options.scrollVertically = self.scrollVertically;
 
     return options;
 }

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -25,7 +25,7 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
  UIViewControllerPreviewingDelegate
 >
 
-@property (nonatomic, strong) UICollectionViewFlowLayout *layout;
+@property (nonatomic, readonly) UICollectionViewFlowLayout *layout;
 @property (nonatomic, strong) NSMutableArray *internalSelectedAssets;
 @property (nonatomic, strong) id<WPMediaAsset> capturedAsset;
 @property (nonatomic, strong) WPMediaCapturePreviewCollectionView *captureCell;
@@ -57,7 +57,6 @@ static CGFloat SelectAnimationTime = 0.2;
     UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
     self = [self initWithCollectionViewLayout:layout];
     if (self) {
-        _layout = layout;
         _internalSelectedAssets = [[NSMutableArray alloc] init];
         _capturedAsset = nil;
         _options = [options copy];
@@ -144,11 +143,16 @@ static CGFloat SelectAnimationTime = 0.2;
     }
 }
 
+- (UICollectionViewFlowLayout *)layout
+{
+    return (UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout;
+}
+
 - (void)setupLayout
 {
     CGFloat photoSpacing = 1.0f;
     CGFloat photoSize;
-    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout;
+    UICollectionViewFlowLayout *layout = self.layout;
     CGFloat frameWidth = self.view.frame.size.width;
     CGFloat frameHeight = self.view.frame.size.width - self.topLayoutGuide.length;
     CGFloat dimensionToUse = frameWidth;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -176,7 +176,6 @@ static CGFloat SelectAnimationTime = 0.2;
                                          frameWidth:dimensionToUse];
 
     self.cameraPreviewSize = CGSizeMake(photoSize, photoSize);
-    self.collectionView.bounces = YES;
     layout.itemSize = CGSizeMake(photoSize, photoSize);
     layout.minimumLineSpacing = photoSpacing;
     layout.minimumInteritemSpacing = photoSpacing;
@@ -352,8 +351,7 @@ static CGFloat SelectAnimationTime = 0.2;
         dispatch_async(dispatch_get_main_queue(), ^{                
             strongSelf.collectionView.allowsSelection = YES;
             strongSelf.collectionView.allowsMultipleSelection = strongSelf.options.allowMultipleSelection;
-            strongSelf.collectionView.scrollEnabled = YES;
-            strongSelf.collectionView.bounces = YES;
+            strongSelf.collectionView.scrollEnabled = YES;            
             [strongSelf refreshSelection];
             [strongSelf.collectionView reloadData];
 


### PR DESCRIPTION
This PR refactor the code to set layout and scrolling horizontally or vertically to all be part of `WPMediaPickerViewController` instead of being split between `WPInputMediaViewController` and `WPMediaPickerViewController`.

It also moves the `scrollDirection` option to inside `WPMediaPickerOptions` to make it more consistent.

To test:
 - Launch the demo app
 - Check the input picker and the full screen picker on vertical and horizontal scroll.
