### PR TITLE
Make sure that case breaks.

### DIFF
--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -126,6 +126,7 @@
             [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
                 [self loadDataWithOptions:options success:successBlock failure:failureBlock];
             }];
+            return;
         }
         case PHAuthorizationStatusAuthorized: {
             dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
@@ -150,6 +151,7 @@
                     }
                 }
             });
+            return;
         }
     }
 }


### PR DESCRIPTION
Fixes #239 

To test:
 - Start the demo app on a device for a first time ( or reset the device privacy settings)
 - Tap on the +
 - Check that the authorization alert shows up and the app doesn't crash.

