### PR TITLE
Add opaque background color to navigation picker

### DIFF
--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -54,7 +54,8 @@ static NSString *const ArrowDown = @"\u25be";
 {
     [super viewDidLoad];
 
-    // Do any additional setup after loading the view.
+    self.view.backgroundColor = [UIColor whiteColor];
+
     [self setupNavigationController];
 }
 


### PR DESCRIPTION
Fixes a bug on iOS 11 where the navigation picker has a clear background, making it see-through when first presented:

![picker-x-background](https://user-images.githubusercontent.com/4780/30856544-9bd3bda0-a2b0-11e7-899b-3c167f628e9d.gif)

After fix:

![picker-x-background-2](https://user-images.githubusercontent.com/4780/30856552-a2e8a39e-a2b0-11e7-9a69-efffe20d39ba.gif)


To test:

* Ensure that the navigation picker presents correctly on iOS 11.