### PR TITLE
Placeholder design update for audio and docs

### DIFF
--- a/Example/WPMediaPicker/AppDelegate.m
+++ b/Example/WPMediaPicker/AppDelegate.m
@@ -33,9 +33,14 @@
     [[UITableView appearanceWhenContainedIn:[WPNavigationMediaPickerViewController class],nil] setBackgroundColor:[UIColor whiteColor]];
     //Configure background color for media cell while loading image.
     UIColor *cellBackgroundColor = [UIColor colorWithRed:243/255.0f green:246/255.0f blue:248/255.0f alpha:1.0f];
-    [[WPMediaCollectionViewCell appearanceWhenContainedIn:[WPMediaPickerViewController class],nil] setBackgroundColor:cellBackgroundColor];
-    [[WPMediaCollectionViewCell appearanceWhenContainedIn:[WPInputMediaPickerViewController class],nil] setBackgroundColor:cellBackgroundColor];
+    [[WPMediaCollectionViewCell appearanceWhenContainedIn:[WPMediaPickerViewController class],nil] setLoadingBackgroundColor:cellBackgroundColor];
+    [[WPMediaCollectionViewCell appearanceWhenContainedIn:[WPInputMediaPickerViewController class],nil] setLoadingBackgroundColor:cellBackgroundColor];
     [[WPMediaGroupTableViewCell appearance] setPosterBackgroundColor:cellBackgroundColor];
+
+    //Configure placeholder background color for media cell.
+    UIColor *placeholderCellBackgroundColor = [UIColor lightGrayColor];
+    [[WPMediaCollectionViewCell appearanceWhenContainedIn:[WPMediaPickerViewController class],nil] setPlaceholderBackgroundColor:placeholderCellBackgroundColor];
+    [[WPMediaCollectionViewCell appearanceWhenContainedIn:[WPInputMediaPickerViewController class],nil] setPlaceholderBackgroundColor:placeholderCellBackgroundColor];
 
     //Configure color for activity indicator while loading media collection
     [[UIActivityIndicatorView appearanceWhenContainedIn:[WPMediaPickerViewController class],nil] setColor:[UIColor grayColor]];

--- a/Example/WPMediaPicker/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/WPMediaPicker/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -131,6 +131,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    },
+    {
       "size" : "24x24",
       "idiom" : "watch",
       "scale" : "2x",
@@ -183,6 +188,11 @@
       "scale" : "2x",
       "role" : "quickLook",
       "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Pod/Classes/WPMediaCollectionViewCell.h
+++ b/Pod/Classes/WPMediaCollectionViewCell.h
@@ -4,12 +4,18 @@
 @interface WPMediaCollectionViewCell : UICollectionViewCell
 
 @property (nonatomic, strong) id<WPMediaAsset> asset;
+
 @property (nonatomic, assign) NSInteger position;
 
 @property (nonatomic, strong) UIColor *placeholderTintColor UI_APPEARANCE_SELECTOR;
+
+@property (nonatomic, strong) UIColor *loadingBackgroundColor UI_APPEARANCE_SELECTOR;
+
+@property (nonatomic, strong) UIColor *placeholderBackgroundColor UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, strong) UIColor *positionLabelUnselectedTintColor UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, assign) BOOL hiddenSelectionIndicator;
 
 @end
+

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -56,7 +56,8 @@ static const CGFloat LabelRegularFontSize = 13;
     [self setPosition:NSNotFound];
     [self setSelected:NO];
     self.imageView.contentMode = UIViewContentModeScaleAspectFill;
-    self.imageView.backgroundColor = self.backgroundColor;
+    self.imageView.backgroundColor = self.loadingBackgroundColor;
+    self.backgroundColor = self.loadingBackgroundColor;
     self.placeholderStackView.hidden = YES;
     self.documentNameLabel.text = nil;
 }
@@ -69,6 +70,9 @@ static const CGFloat LabelRegularFontSize = 13;
 - (void)commonInit
 {
     self.isAccessibilityElement = YES;
+    _placeholderBackgroundColor = self.backgroundColor;
+    _loadingBackgroundColor = self.backgroundColor;
+
     _imageView = [[UIImageView alloc] init];
     _imageView.isAccessibilityElement = YES;
     _imageView.contentMode = UIViewContentModeScaleAspectFill;
@@ -193,6 +197,7 @@ static const CGFloat LabelRegularFontSize = 13;
 
 - (void)displayAssetTypePlaceholder
 {
+    self.backgroundColor = self.placeholderBackgroundColor;
     self.placeholderStackView.hidden = NO;
     self.imageView.hidden = YES;
     UIImage * iconImage = nil;
@@ -244,7 +249,7 @@ static const CGFloat LabelRegularFontSize = 13;
         case WPMediaTypeOther:
             [self displayAssetTypePlaceholder];
         default:
-        break;
+            break;
     }
 }
 
@@ -261,6 +266,7 @@ static const CGFloat LabelRegularFontSize = 13;
         NSString *caption = [WPDateTimeHelpers stringFromTimeInterval:[self.asset duration]];
         [self setCaption:caption];
     }
+    self.backgroundColor = self.loadingBackgroundColor;
     self.imageView.hidden = NO;
     self.placeholderStackView.hidden = YES;
     BOOL animated = ([NSDate timeIntervalSinceReferenceDate] - timestamp) > ThresholdForAnimation;

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -137,11 +137,13 @@ static const CGFloat LabelRegularFontSize = 13;
     _placeholderStackView.axis = UILayoutConstraintAxisVertical;
     _placeholderStackView.alignment = UIStackViewAlignmentCenter;
     _placeholderStackView.distribution = UIStackViewDistributionEqualSpacing;
-    _placeholderStackView.spacing = 3.0;
-
+    _placeholderStackView.layoutMargins = UIEdgeInsetsMake(0.0, 3.0, 0.0, 3.0);
+    _placeholderStackView.layoutMarginsRelativeArrangement = YES;
+    _placeholderStackView.spacing = 2.0;
+    
     _documentNameLabel = [UILabel new];
     _documentNameLabel.textAlignment = NSTextAlignmentCenter;
-    _documentNameLabel.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize] weight: UIFontWeightRegular];
+    _documentNameLabel.font = [UIFont systemFontOfSize:labelTextSize weight: UIFontWeightRegular];
     _documentNameLabel.adjustsFontSizeToFitWidth = NO;
     _documentNameLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
     _documentNameLabel.textColor = _placeholderTintColor;

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -18,7 +18,7 @@ static const CGFloat LabelRegularFontSize = 13;
 
 @property (nonatomic, strong) UIStackView *placeholderStackView;
 @property (nonatomic, strong) UIImageView *placeholderImageView;
-@property (nonatomic, strong) UILabel *documentExtensionLabel;
+@property (nonatomic, strong) UILabel *documentNameLabel;
 
 @property (nonatomic, assign) WPMediaRequestID requestKey;
 
@@ -58,7 +58,7 @@ static const CGFloat LabelRegularFontSize = 13;
     self.imageView.contentMode = UIViewContentModeScaleAspectFill;
     self.imageView.backgroundColor = self.backgroundColor;
     self.placeholderStackView.hidden = YES;
-    self.documentExtensionLabel.text = nil;
+    self.documentNameLabel.text = nil;
 }
 
 - (void)layoutSubviews {
@@ -137,18 +137,20 @@ static const CGFloat LabelRegularFontSize = 13;
     _placeholderStackView.axis = UILayoutConstraintAxisVertical;
     _placeholderStackView.alignment = UIStackViewAlignmentCenter;
     _placeholderStackView.distribution = UIStackViewDistributionEqualSpacing;
-    _placeholderStackView.spacing = 8.0;
+    _placeholderStackView.spacing = 3.0;
 
-    _documentExtensionLabel = [UILabel new];
-    _documentExtensionLabel.textAlignment = NSTextAlignmentCenter;
-    _documentExtensionLabel.font = [UIFont boldSystemFontOfSize:[UIFont smallSystemFontSize]];
-    _documentExtensionLabel.textColor = _placeholderTintColor;
+    _documentNameLabel = [UILabel new];
+    _documentNameLabel.textAlignment = NSTextAlignmentCenter;
+    _documentNameLabel.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize] weight: UIFontWeightRegular];
+    _documentNameLabel.adjustsFontSizeToFitWidth = NO;
+    _documentNameLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    _documentNameLabel.textColor = _placeholderTintColor;
 
     _placeholderImageView = [UIImageView new];
     _placeholderImageView.contentMode = UIViewContentModeCenter;
 
     [_placeholderStackView addArrangedSubview:_placeholderImageView];
-    [_placeholderStackView addArrangedSubview:_documentExtensionLabel];
+    [_placeholderStackView addArrangedSubview:_documentNameLabel];
 
     UIStackView *wrapper = [[UIStackView alloc] initWithFrame:self.bounds];
     wrapper.axis = UILayoutConstraintAxisHorizontal;
@@ -193,39 +195,38 @@ static const CGFloat LabelRegularFontSize = 13;
     self.imageView.hidden = YES;
     UIImage * iconImage = nil;
     NSString *caption = nil;
-    NSString *extension = nil;
-    if ([self.asset respondsToSelector:@selector(filename)]) {
-        caption = [self.asset filename];
-    }
+    NSString *mediaName = nil;
 
     switch (self.asset.assetType) {
         case WPMediaTypeImage:
             iconImage = [WPMediaPickerResources imageNamed:@"gridicons-camera" withExtension:@"png"];
-            extension = NSLocalizedString(@"IMAGE", @"Label displayed on audio media items.");
+            mediaName = NSLocalizedString(@"image", @"Label displayed on image media items.");
             caption = nil;
             break;
         case WPMediaTypeVideo:
             iconImage = [WPMediaPickerResources imageNamed:@"gridicons-video-camera" withExtension:@"png"];
-            extension = NSLocalizedString(@"VIDEO", @"Label displayed on audio media items.");
+            mediaName = NSLocalizedString(@"video", @"Label displayed on video media items.");
             caption = [WPDateTimeHelpers stringFromTimeInterval:[self.asset duration]];
             break;
         case WPMediaTypeAudio:
-            iconImage = [WPMediaPickerResources imageNamed:@"gridicons-audio" withExtension:@"png"];
-            extension = NSLocalizedString(@"AUDIO", @"Label displayed on audio media items.");
+            iconImage = [WPMediaPickerResources imageNamed:@"griddocumentExtensionLabelicons-audio" withExtension:@"png"];
+            mediaName = NSLocalizedString(@"audio", @"Label displayed on audio media items.");
             caption = [WPDateTimeHelpers stringFromTimeInterval:[self.asset duration]];
             break;
         case WPMediaTypeOther:
             iconImage = [WPMediaPickerResources imageNamed:@"gridicons-pages" withExtension:@"png"];
+            mediaName = NSLocalizedString(@"other", @"Label displayed on media items that are not video, image, or audio.");
+            caption = nil;
             break;
         default:
             break;
     }
-    if ([self.asset respondsToSelector:@selector(fileExtension)]) {
-        extension = [[self.asset fileExtension] uppercaseString];
+    if ([self.asset respondsToSelector:@selector(filename)]) {
+        mediaName = [[self.asset filename] lowercaseString];
     }
     self.placeholderImageView.image = [iconImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     [self setCaption:caption];
-    self.documentExtensionLabel.text = extension;
+    self.documentNameLabel.text = mediaName;
 }
 
 - (void)setAsset:(id<WPMediaAsset>)asset {
@@ -331,7 +332,7 @@ static const CGFloat LabelRegularFontSize = 13;
 {
     _placeholderTintColor = placeholderTintColor;
     _placeholderImageView.tintColor = placeholderTintColor;
-    _documentExtensionLabel.textColor = placeholderTintColor;
+    _documentNameLabel.textColor = placeholderTintColor;
 }
 
 - (void)setSelected:(BOOL)selected

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -209,7 +209,7 @@ static const CGFloat LabelRegularFontSize = 13;
             caption = [WPDateTimeHelpers stringFromTimeInterval:[self.asset duration]];
             break;
         case WPMediaTypeAudio:
-            iconImage = [WPMediaPickerResources imageNamed:@"griddocumentExtensionLabelicons-audio" withExtension:@"png"];
+            iconImage = [WPMediaPickerResources imageNamed:@"gridicons-audio" withExtension:@"png"];
             mediaName = NSLocalizedString(@"audio", @"Label displayed on audio media items.");
             caption = [WPDateTimeHelpers stringFromTimeInterval:[self.asset duration]];
             break;

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -137,10 +137,10 @@ static const CGFloat LabelRegularFontSize = 13;
     _placeholderStackView.axis = UILayoutConstraintAxisVertical;
     _placeholderStackView.alignment = UIStackViewAlignmentCenter;
     _placeholderStackView.distribution = UIStackViewDistributionEqualSpacing;
-    _placeholderStackView.layoutMargins = UIEdgeInsetsMake(0.0, 3.0, 0.0, 3.0);
+    _placeholderStackView.layoutMargins = UIEdgeInsetsMake(0.0, 3.0, 5.0, 3.0);
     _placeholderStackView.layoutMarginsRelativeArrangement = YES;
     _placeholderStackView.spacing = 2.0;
-    
+
     _documentNameLabel = [UILabel new];
     _documentNameLabel.textAlignment = NSTextAlignmentCenter;
     _documentNameLabel.font = [UIFont systemFontOfSize:labelTextSize weight: UIFontWeightRegular];


### PR DESCRIPTION
This PR makes some minor tweaks to the placeholder design in `WPMediaCollectionViewCell` as spelled out by @iamthomasbishop [here](https://github.com/wordpress-mobile/MediaPicker-iOS/issues/245#issuecomment-332965202).  I tried to find a happy balance for spacing & insets given the different cell sizes on various devices:

**iPhone SE:**
<img width="321" alt="screen shot 2017-09-29 at 12 30 01 pm" src="https://user-images.githubusercontent.com/154014/31028633-41c5af74-a514-11e7-8f33-79e181417be4.png">

**iPhone 8+:**
<img width="419" alt="screen shot 2017-09-29 at 12 28 57 pm" src="https://user-images.githubusercontent.com/154014/31028624-3b26cdd8-a514-11e7-92c9-94defb7e220d.png">

**iPhone 8:**
<img width="374" alt="screen shot 2017-09-29 at 12 31 09 pm" src="https://user-images.githubusercontent.com/154014/31028635-45c6367a-a514-11e7-91fc-e174ac368d55.png">

Note, the color/tint updates will be in a separate PR in WPiOS. 

Ref #245 

**To Test:**
Build and run both the Example App as well as WPiOS via [this branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/245-media-placeholder-cell-update). 

@SergioEstevao would you mind reviewing?