### PR TITLE
Add configurable overlay views to cells

### DIFF
--- a/Example/WPMediaPicker.xcodeproj/project.pbxproj
+++ b/Example/WPMediaPicker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17475FB81FB46DED00252689 /* SampleCellOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17475FB71FB46DED00252689 /* SampleCellOverlayView.m */; };
 		17F64FE01E6DDC74006C5A2B /* CustomPreviewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
@@ -40,6 +41,8 @@
 
 /* Begin PBXFileReference section */
 		1120051BDDDC8A558883872E /* Pods-WPMediaPicker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WPMediaPicker.release.xcconfig"; path = "Pods/Target Support Files/Pods-WPMediaPicker/Pods-WPMediaPicker.release.xcconfig"; sourceTree = "<group>"; };
+		17475FB61FB46DED00252689 /* SampleCellOverlayView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SampleCellOverlayView.h; sourceTree = "<group>"; };
+		17475FB71FB46DED00252689 /* SampleCellOverlayView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SampleCellOverlayView.m; sourceTree = "<group>"; };
 		17F64FDE1E6DDC74006C5A2B /* CustomPreviewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomPreviewViewController.h; sourceTree = "<group>"; };
 		17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomPreviewViewController.m; sourceTree = "<group>"; };
 		5709B45B57F590232B3E5DA7 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -147,6 +150,8 @@
 				B5FF3BE91CAD8AB100C1D597 /* PostProcessingViewController.m */,
 				17F64FDE1E6DDC74006C5A2B /* CustomPreviewViewController.h */,
 				17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */,
+				17475FB61FB46DED00252689 /* SampleCellOverlayView.h */,
+				17475FB71FB46DED00252689 /* SampleCellOverlayView.m */,
 				6003F59C195388D20070C39A /* AppDelegate.h */,
 				6003F59D195388D20070C39A /* AppDelegate.m */,
 				6003F5A8195388D20070C39A /* Images.xcassets */,
@@ -424,6 +429,7 @@
 				17F64FE01E6DDC74006C5A2B /* CustomPreviewViewController.m in Sources */,
 				B5FF3BEA1CAD8AB100C1D597 /* PostProcessingViewController.m in Sources */,
 				6003F59E195388D20070C39A /* AppDelegate.m in Sources */,
+				17475FB81FB46DED00252689 /* SampleCellOverlayView.m in Sources */,
 				FFFFD8811A447E67000FC184 /* DemoViewController.m in Sources */,
 				6003F59A195388D20070C39A /* main.m in Sources */,
 				FFE69A1D1B14AB840073C2EB /* OptionsViewController.m in Sources */,

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -3,6 +3,7 @@
 #import "WPPHAssetDataSource.h"
 #import "OptionsViewController.h"
 #import "PostProcessingViewController.h"
+#import "SampleCellOverlayView.h"
 #import <WPMediaPicker/WPMediaPicker.h>
 
 @interface DemoViewController () <WPMediaPickerViewControllerDelegate, OptionsViewControllerDelegate, UITextFieldDelegate>
@@ -43,7 +44,8 @@
                      MediaPickerOptionsPostProcessingStep:@(NO),
                      MediaPickerOptionsFilterType:@(WPMediaTypeImage | WPMediaTypeVideo),
                      MediaPickerOptionsCustomPreview:@(NO),
-                     MediaPickerOptionsScrollInputPickerVertically:@(YES)
+                     MediaPickerOptionsScrollInputPickerVertically:@(YES),
+                     MediaPickerOptionsShowSampleCellOverlays:@(NO)
                      };
 
 }
@@ -211,7 +213,19 @@
     assetViewController.delegate = picker;
     assetViewController.selected = [picker.selectedAssets containsObject:asset];
     return assetViewController;
+}
 
+- (BOOL)mediaPickerController:(WPMediaPickerViewController *)picker shouldShowOverlayViewForCellForAsset:(id<WPMediaAsset>)asset
+{
+    return [self.options[MediaPickerOptionsShowSampleCellOverlays] boolValue];
+}
+
+- (void)mediaPickerController:(WPMediaPickerViewController *)picker willShowOverlayView:(UIView *)overlayView forCellForAsset:(id<WPMediaAsset>)asset
+{
+    if ([overlayView isKindOfClass:[SampleCellOverlayView class]]) {
+        SampleCellOverlayView *view = (SampleCellOverlayView *)overlayView;
+        [view setLabelText:asset.filename];
+    }
 }
 
 #pragma - Actions
@@ -247,6 +261,10 @@
     self.mediaPicker.modalPresentationStyle = UIModalPresentationPopover;
     UIPopoverPresentationController *ppc = self.mediaPicker.popoverPresentationController;
     ppc.barButtonItem = sender;
+
+    if ([self.options[MediaPickerOptionsShowSampleCellOverlays] boolValue]) {
+        [self.mediaPicker.mediaPicker registerClassForReusableCellOverlayViews:[SampleCellOverlayView class]];
+    }
     
     [self presentViewController:self.mediaPicker animated:YES completion:nil];
     [self.quickInputTextField resignFirstResponder];

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -140,6 +140,7 @@
         [self.mediaInputViewController didMoveToParentViewController:nil];
     } else {
         self.mediaInputViewController = [[WPInputMediaPickerViewController alloc] init];
+        [self.mediaInputViewController.mediaPicker registerClassForReusableCellOverlayViews:[SampleCellOverlayView class]];
     }    
 
     [self addChildViewController:self.mediaInputViewController];

--- a/Example/WPMediaPicker/OptionsViewController.h
+++ b/Example/WPMediaPicker/OptionsViewController.h
@@ -8,6 +8,7 @@ extern NSString const *MediaPickerOptionsPostProcessingStep;
 extern NSString const *MediaPickerOptionsFilterType;
 extern NSString const *MediaPickerOptionsCustomPreview;
 extern NSString const *MediaPickerOptionsScrollInputPickerVertically;
+extern NSString const *MediaPickerOptionsShowSampleCellOverlays;
 
 @class OptionsViewController;
 

--- a/Example/WPMediaPicker/OptionsViewController.m
+++ b/Example/WPMediaPicker/OptionsViewController.m
@@ -10,6 +10,7 @@ NSString const *MediaPickerOptionsPostProcessingStep = @"MediaPickerOptionsPostP
 NSString const *MediaPickerOptionsFilterType = @"MediaPickerOptionsFilterType";
 NSString const *MediaPickerOptionsCustomPreview = @"MediaPickerOptionsCustomPreview";
 NSString const *MediaPickerOptionsScrollInputPickerVertically = @"MediaPickerOptionsScrollInputPickerVertically";
+NSString const *MediaPickerOptionsShowSampleCellOverlays = @"MediaPickerOptionsShowSampleCellOverlays";
 
 typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellShowMostRecentFirst,
@@ -20,6 +21,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellMediaType,
     OptionsViewControllerCellCustomPreview,
     OptionsViewControllerCellInputPickerScroll,
+    OptionsViewControllerCellShowSampleCellOverlays,
     OptionsViewControllerCellTotal
 };
 
@@ -33,6 +35,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
 @property (nonatomic, strong) UITableViewCell *filterMediaCell;
 @property (nonatomic, strong) UITableViewCell *customPreviewCell;
 @property (nonatomic, strong) UITableViewCell *scrollInputPickerCell;
+@property (nonatomic, strong) UITableViewCell *cellOverlaysCell;
 
 @end
 
@@ -94,6 +97,11 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     self.scrollInputPickerCell.accessoryView = [[UISwitch alloc] init];
     ((UISwitch *)self.scrollInputPickerCell.accessoryView).on = [self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue];
     self.scrollInputPickerCell.textLabel.text = @"Scroll Input Picker Vertically";
+
+    self.cellOverlaysCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    self.cellOverlaysCell.accessoryView = [[UISwitch alloc] init];
+    ((UISwitch *)self.cellOverlaysCell.accessoryView).on = [self.options[MediaPickerOptionsShowSampleCellOverlays] boolValue];
+    self.cellOverlaysCell.textLabel.text = @"Show Sample Cell Overlays";
 }
 
 #pragma mark - Table view data source
@@ -135,6 +143,9 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
         case OptionsViewControllerCellInputPickerScroll:
             return self.scrollInputPickerCell;
             break;
+        case OptionsViewControllerCellShowSampleCellOverlays:
+            return self.cellOverlaysCell;
+            break;
         default:
             break;
     }
@@ -162,6 +173,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
              MediaPickerOptionsFilterType:@(filterType),
              MediaPickerOptionsCustomPreview:@(((UISwitch *)self.customPreviewCell.accessoryView).on),
              MediaPickerOptionsScrollInputPickerVertically:@(((UISwitch *)self.scrollInputPickerCell.accessoryView).on),
+             MediaPickerOptionsShowSampleCellOverlays:@(((UISwitch *)self.cellOverlaysCell.accessoryView).on),
              };
         
         [delegate optionsViewController:self changed:newOptions];

--- a/Example/WPMediaPicker/SampleCellOverlayView.h
+++ b/Example/WPMediaPicker/SampleCellOverlayView.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface SampleCellOverlayView : UIView
+
+@property (nonatomic, copy) NSString *labelText;
+
+@end

--- a/Example/WPMediaPicker/SampleCellOverlayView.m
+++ b/Example/WPMediaPicker/SampleCellOverlayView.m
@@ -1,0 +1,64 @@
+#import "SampleCellOverlayView.h"
+
+@interface SampleCellOverlayView ()
+@property (nonatomic, strong) UIView *labelBackgroundView;
+@property (nonatomic, strong) UILabel *label;
+@end
+
+@implementation SampleCellOverlayView
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        [self addBackgroundView];
+        [self addLabel];
+    }
+
+    return self;
+}
+
+- (void)addBackgroundView
+{
+    UIView *labelBackgroundView = [UIView new];
+    labelBackgroundView.backgroundColor = [UIColor darkGrayColor];
+    labelBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [self addSubview:labelBackgroundView];
+    [NSLayoutConstraint activateConstraints:@[
+                                              [labelBackgroundView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+                                              [labelBackgroundView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+                                              [labelBackgroundView.topAnchor constraintEqualToAnchor:self.topAnchor],
+                                              [labelBackgroundView.heightAnchor constraintEqualToConstant:20.0],
+                                              ]];
+
+    self.labelBackgroundView = labelBackgroundView;
+}
+
+- (void)addLabel
+{
+    UILabel *label = [UILabel new];
+    label.textAlignment = NSTextAlignmentCenter;
+    label.font = [UIFont boldSystemFontOfSize:12.0];
+    label.textColor = [UIColor whiteColor];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [self.labelBackgroundView addSubview:label];
+    [NSLayoutConstraint activateConstraints:@[
+                                              [label.centerXAnchor constraintEqualToAnchor:self.labelBackgroundView.centerXAnchor],
+                                              [label.centerYAnchor constraintEqualToAnchor:self.labelBackgroundView.centerYAnchor]
+                                              ]];
+
+    self.label = label;
+}
+
+- (void)setLabelText:(NSString *)labelText
+{
+    self.label.text = labelText;
+}
+
+- (NSString *)labelText
+{
+    return self.label.text;
+}
+
+@end

--- a/Pod/Classes/WPMediaCollectionViewCell.h
+++ b/Pod/Classes/WPMediaCollectionViewCell.h
@@ -17,5 +17,7 @@
 
 @property (nonatomic, assign) BOOL hiddenSelectionIndicator;
 
+@property (nonatomic, strong) UIView *overlayView;
+
 @end
 

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -61,7 +61,7 @@ static const CGFloat LabelRegularFontSize = 13;
     self.placeholderStackView.hidden = YES;
     self.documentNameLabel.text = nil;
 
-    self.overlayView = nil;
+    self.overlayView.hidden = YES;
 }
 
 - (void)layoutSubviews {

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -60,6 +60,8 @@ static const CGFloat LabelRegularFontSize = 13;
     self.backgroundColor = self.loadingBackgroundColor;
     self.placeholderStackView.hidden = YES;
     self.documentNameLabel.text = nil;
+
+    self.overlayView = nil;
 }
 
 - (void)layoutSubviews {
@@ -313,6 +315,28 @@ static const CGFloat LabelRegularFontSize = 13;
             self.imageView.alpha = 1.0;
             self.imageView.image = image;
         }
+    }
+}
+
+- (void)setOverlayView:(UIView *)overlayView
+{
+    if (_overlayView != overlayView) {
+        [_overlayView removeFromSuperview];
+
+        _overlayView = overlayView;
+    }
+
+    if (_overlayView) {
+        [self insertSubview:overlayView aboveSubview:self.contentView];
+
+        overlayView.translatesAutoresizingMaskIntoConstraints = NO;
+
+        [NSLayoutConstraint activateConstraints:@[
+                                                  [overlayView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor],
+                                                  [overlayView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
+                                                  [overlayView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor],
+                                                  [overlayView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor],
+                                                  ]];
     }
 }
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -162,7 +162,7 @@
  *  @param overlayView The overlay view to configure.
  *  @param asset       The asset to configure the overlay for.
  */
-- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker willShowOverlayView:(UIView *)overlayView forCellForAsset:(nonnull id<WPMediaAsset>)asset;
+- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker willShowOverlayView:(nonnull UIView *)overlayView forCellForAsset:(nonnull id<WPMediaAsset>)asset;
 
 @end
 
@@ -233,7 +233,7 @@
  */
 - (CGFloat)cellSizeForPhotosPerLineCount:(NSUInteger)photosPerLine photoSpacing:(CGFloat)photoSpacing frameWidth:(CGFloat)frameWidth;
 
-- (void)registerClassForReusableCellOverlayViews:(Class)overlayClass;
+- (void)registerClassForReusableCellOverlayViews:(nonnull Class)overlayClass;
 
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -144,7 +144,8 @@
 
 /**
  *  Asks the delegate whether an overlay view should be shown for the cell for
- *  the specified media asset.
+ *  the specified media asset. If you return `YES` from this method, you must
+ *  have registered a reuse class though `-[WPMediaPickerViewController registerClassForReusableCellOverlayViews:]`.
  *
  *  @param asset The asset to display an overlay view for.
  *  @return `YES` if an overlay view should be displayed, `NO`, if not.
@@ -233,6 +234,11 @@
  */
 - (CGFloat)cellSizeForPhotosPerLineCount:(NSUInteger)photosPerLine photoSpacing:(CGFloat)photoSpacing frameWidth:(CGFloat)frameWidth;
 
+/**
+ Register a `UIView` subclass to use for overlay views applied to cells. For
+ overlays to be displayed, you must register a class using this method, and then
+ return `YES` from `mediaPickerController:shouldShowOverlayViewForCellForAsset:`
+ */
 - (void)registerClassForReusableCellOverlayViews:(nonnull Class)overlayClass;
 
 @end

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -233,5 +233,7 @@
  */
 - (CGFloat)cellSizeForPhotosPerLineCount:(NSUInteger)photosPerLine photoSpacing:(CGFloat)photoSpacing frameWidth:(CGFloat)frameWidth;
 
+- (void)registerClassForReusableCellOverlayViews:(Class)overlayClass;
+
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -142,6 +142,28 @@
  */
 - (void)mediaPickerControllerDidEndLoadingData:(nonnull WPMediaPickerViewController *)picker;
 
+/**
+ *  Asks the delegate whether an overlay view should be shown for the cell for
+ *  the specified media asset.
+ *
+ *  @param asset The asset to display an overlay view for.
+ *  @return `YES` if an overlay view should be displayed, `NO`, if not.
+ *
+ *  If this method is not implemented, no overlay view will be displayed.
+ */
+- (BOOL)mediaPickerController:(nonnull WPMediaPickerViewController *)picker shouldShowOverlayViewForCellForAsset:(nonnull id<WPMediaAsset>)asset;
+
+/**
+ *  Gives the delegate an opportunity to configure the overlay view for the
+ *  specified media asset's cell. You can implement this method to update the
+ *  overlay view as required for the asset (for example, to show a loading
+ *  indicator if the asset is currently being loaded).
+ *
+ *  @param overlayView The overlay view to configure.
+ *  @param asset       The asset to configure the overlay for.
+ */
+- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker willShowOverlayView:(UIView *)overlayView forCellForAsset:(nonnull id<WPMediaAsset>)asset;
+
 @end
 
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -36,6 +36,10 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 @property (nonatomic, assign) BOOL refreshGroupFirstTime;
 @property (nonatomic, strong) UILongPressGestureRecognizer *longPressGestureRecognizer;
 @property (nonatomic, strong) NSIndexPath *assetIndexInPreview;
+
+@property (nonatomic, strong, nullable) Class overlayViewClass;
+@property (nonatomic, strong) NSArray<UIView *> * reusableOverlayViews;
+
 /**
  The size of the camera preview cell
  */
@@ -151,6 +155,15 @@ static CGFloat SelectAnimationTime = 0.2;
             [self.collectionView reloadData];
         }
     }
+}
+
+- (void)registerClassForReusableCellOverlayViews:(Class)overlayClass
+{
+    NSParameterAssert([overlayClass isSubclassOfClass:[UIView class]]);
+
+    self.overlayViewClass = overlayClass;
+
+    self.reusableOverlayViews = @[];
 }
 
 - (UICollectionViewFlowLayout *)layout
@@ -494,8 +507,14 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (UIView *)dequeueReusableOverlayView
 {
-    UIView *view = [UIView new];
-    view.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.3];
+    UIView *view = nil;
+
+    if (self.overlayViewClass) {
+        view = [self.overlayViewClass new];
+    } else {
+        view = [UIView new];
+    }
+
     return view;
 }
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -492,6 +492,13 @@ static CGFloat SelectAnimationTime = 0.2;
     return asset;
 }
 
+- (UIView *)dequeueReusableOverlayView
+{
+    UIView *view = [UIView new];
+    view.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.3];
+    return view;
+}
+
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     id<WPMediaAsset> asset = [self assetForPosition:indexPath];
@@ -514,7 +521,27 @@ static CGFloat SelectAnimationTime = 0.2;
         cell.selected = NO;
     }
 
+    [self configureOverlayViewForCell:cell];
+    
     return cell;
+}
+
+- (void)configureOverlayViewForCell:(WPMediaCollectionViewCell *)cell
+{
+    UIView *overlayView = nil;
+
+    if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:shouldShowOverlayViewForCellForAsset:)]) {
+        if ([self.mediaPickerDelegate mediaPickerController:self shouldShowOverlayViewForCellForAsset:cell.asset]) {
+            overlayView = [self dequeueReusableOverlayView];
+            cell.overlayView = overlayView;
+        }
+    }
+
+    if (overlayView && [self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:willShowOverlayView:forCellForAsset:)]) {
+        [self.mediaPickerDelegate mediaPickerController:self
+                                    willShowOverlayView:cell.overlayView
+                                        forCellForAsset:cell.asset];
+    }
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -519,11 +519,9 @@ static CGFloat SelectAnimationTime = 0.2;
         return view;
     }
 
-    if (self.overlayViewClass) {
-        return [self.overlayViewClass new];
-    } else {
-        return [UIView new];
-    }
+    NSAssert(self.overlayViewClass != nil, @"Media Picker: Attempted to dequeue a reusable overlay view, but no reuse class has been set.");
+
+    return [self.overlayViewClass new];
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -625,7 +625,9 @@ referenceSizeForFooterInSection:(NSInteger)section
 
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    [self configureOverlayViewForCell:cell];
+    if ([cell isKindOfClass:[WPMediaCollectionViewCell class]]) {
+        [self configureOverlayViewForCell:(WPMediaCollectionViewCell *)cell];
+    }
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didEndDisplayingCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -210,6 +210,24 @@ static NSString *const ArrowDown = @"\u25be";
     }
 }
 
+- (BOOL)mediaPickerController:(WPMediaPickerViewController *)picker shouldShowOverlayViewForCellForAsset:(id<WPMediaAsset>)asset
+{
+    if ([self.delegate respondsToSelector:@selector(mediaPickerController:shouldShowOverlayViewForCellForAsset:)]) {
+        return [self.delegate mediaPickerController:picker shouldShowOverlayViewForCellForAsset:asset];
+    }
+
+    return NO;
+}
+
+- (void)mediaPickerController:(WPMediaPickerViewController *)picker willShowOverlayView:(UIView *)overlayView forCellForAsset:(id<WPMediaAsset>)asset
+{
+    if ([self.delegate respondsToSelector:@selector(mediaPickerController:willShowOverlayView:forCellForAsset:)]) {
+        [self.delegate mediaPickerController:picker
+                         willShowOverlayView:overlayView
+                             forCellForAsset:asset];
+    }
+}
+
 - (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset {
     if ([self.delegate respondsToSelector:@selector(mediaPickerController:previewViewControllerForAsset:)]) {
         return [self.delegate mediaPickerController:picker previewViewControllerForAsset:asset];


### PR DESCRIPTION
Implements #259.

This PR adds a configurable 'overlay' view to cells in the picker. It does so via two new delegate methods on the picker:

```
- (BOOL)mediaPickerController:(WPMediaPickerViewController *)picker shouldShowOverlayViewForCellForAsset:(id<WPMediaAsset>)asset;

- (void)mediaPickerController:(WPMediaPickerViewController *)picker willShowOverlayView:(UIView *)overlayView forCellForAsset:(id<WPMediaAsset>)asset;
```

If the first method isn't implemented, or returns `NO`, no overlays will be shown. The second method gives the delegate an opportunity to customise the overlay view for the specific cell. The overlay view is also exposed as a property on `WPMediaCollectionViewCell`, to allow customisation at other times (for example when an upload completes).

By default, the overlay view will be a plain `UIView`. This can be customised through a new method on `WPMediaPickerController`:

`- (void)registerClassForReusableCellOverlayViews:(Class)overlayClass`
 
If you pass a class to this method when configuring the picker, instances of that class will be instantiated when a new overlay view is needed.

Overlay views are recycled, so that we only create as many as we need for cells displayed onscreen, and aren't constantly recreating them.

I've also added a new option to the demo app where you can toggle on some sample overlays for the cells there.

![simulator screen shot - iphone 8 - 2017-11-09 at 11 20 25](https://user-images.githubusercontent.com/4780/32603412-8ceb93e0-c541-11e7-9b88-bef3b1203ba0.png)

To test:

* Build and run the demo app
* Turn on the new "Show Sample Cell Overlays" option
* Present the picker, and check that you can see the filename shown at the top of the cells
* Ensure you have multiple screens of media items in the picker, and try scrolling through them quickly and check that the overlays show correctly.
* Also in the above situation, try using Xcode's memory graph debugger to check that we only ever create a limited number of cells (should be around 28 on an iPhone 8 sized screen).

Needs review: @SergioEstevao 