### PR TITLE
Use system strings for relative dates.

### DIFF
--- a/Example/Tests/WPDateTimeHelpersTests.m
+++ b/Example/Tests/WPDateTimeHelpersTests.m
@@ -8,6 +8,8 @@
 
 + (NSString *)stringFromTimeInterval:(NSTimeInterval)timeInterval;
 
++ (void)setForcedLocaleIdentifier:(NSString *)localeIdentifier;
+
 @end
 
 @interface WPDateTimeHelpersTest : XCTestCase
@@ -15,6 +17,10 @@
 @end
 
 @implementation WPDateTimeHelpersTest
+
+- (void)tearDown {
+    [WPDateTimeHelpers setForcedLocaleIdentifier:nil];
+}
 
 - (void)testStringFromTimeInterval
 {
@@ -59,8 +65,22 @@
     XCTAssertEqualObjects(@"1:01:07", result);
 }
 
-- (void)testUserFriendlyStringDateFromDate {    
+- (void)testUserFriendlyStringDateFromDate {
+
     XCTAssertThrows([WPDateTimeHelpers userFriendlyStringDateFromDate:nil]);
+
+    [WPDateTimeHelpers setForcedLocaleIdentifier:@"en_us"];
+    NSDate *now = [NSDate new];
+    XCTAssertEqualObjects([WPDateTimeHelpers userFriendlyStringDateFromDate:now], @"Today");
+
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSDate *yesterday = [calendar dateByAddingUnit:NSCalendarUnitDay value:-1 toDate:now options:0];
+    XCTAssertEqualObjects([WPDateTimeHelpers userFriendlyStringDateFromDate:yesterday], @"Yesterday");
+
+    [WPDateTimeHelpers setForcedLocaleIdentifier:@"pt_pt"];
+    XCTAssertEqualObjects([WPDateTimeHelpers userFriendlyStringDateFromDate:now], @"Hoje");
+    XCTAssertEqualObjects([WPDateTimeHelpers userFriendlyStringDateFromDate:yesterday], @"Ontem");
 }
+
 @end
 

--- a/Pod/Classes/WPDateTimeHelpers.m
+++ b/Pod/Classes/WPDateTimeHelpers.m
@@ -1,5 +1,8 @@
 #import "WPDateTimeHelpers.h"
 
+// To use only on unit tests to check results in specific languages
+static NSString *forcedLocaleIdentifier = nil;
+
 @implementation WPDateTimeHelpers
 
 + (NSString *)userFriendlyStringDateFromDate:(NSDate *)date {
@@ -9,11 +12,7 @@
 
     NSCalendar *calendar = [NSCalendar currentCalendar];
     NSDate *oneWeekAgo = [calendar dateByAddingUnit:NSCalendarUnitWeekOfYear value:-1 toDate:now options:0];
-    if ([calendar isDateInToday:date]) {
-        dateString = NSLocalizedString(@"Today", @"Reference to the current day.");
-    } else if ([calendar isDateInYesterday:date]) {
-        dateString = NSLocalizedString(@"Yesterday", @"Reference to the previous day.");
-    } else if ([date compare:oneWeekAgo] == NSOrderedDescending) {
+    if ((![calendar isDateInToday:date] && ![calendar isDateInYesterday:date]) && [date compare:oneWeekAgo] == NSOrderedDescending) {
         dateString = [[[[self class] sharedDateWeekFormatter] stringFromDate:date] capitalizedStringWithLocale:nil];
     }
     return dateString;
@@ -31,6 +30,7 @@
         _sharedDateFormatter = [[NSDateFormatter alloc] init];
         _sharedDateFormatter.dateStyle = NSDateFormatterLongStyle;
         _sharedDateFormatter.timeStyle = NSDateFormatterNoStyle;
+        _sharedDateFormatter.doesRelativeDateFormatting = YES;
     });
     return _sharedDateFormatter;
 }
@@ -82,4 +82,13 @@
     return [[[self class] sharedDateComponentsFormatter] stringFromTimeInterval:interval];
 }
 
++ (void)setForcedLocaleIdentifier:(NSString *)localeIdentifier {
+    forcedLocaleIdentifier = localeIdentifier;
+    if (forcedLocaleIdentifier) {
+        NSLocale *forcedLocale = [[NSLocale alloc] initWithLocaleIdentifier:forcedLocaleIdentifier];
+        self.sharedDateFormatter.locale = forcedLocale;
+    } else {
+        self.sharedDateFormatter.locale = NSLocale.currentLocale;
+    }
+}
 @end

--- a/Pod/Classes/WPDateTimeHelpers.m
+++ b/Pod/Classes/WPDateTimeHelpers.m
@@ -1,8 +1,5 @@
 #import "WPDateTimeHelpers.h"
 
-// To use only on unit tests to check results in specific languages
-static NSString *forcedLocaleIdentifier = nil;
-
 @implementation WPDateTimeHelpers
 
 + (NSString *)userFriendlyStringDateFromDate:(NSDate *)date {
@@ -82,8 +79,7 @@ static NSString *forcedLocaleIdentifier = nil;
     return [[[self class] sharedDateComponentsFormatter] stringFromTimeInterval:interval];
 }
 
-+ (void)setForcedLocaleIdentifier:(NSString *)localeIdentifier {
-    forcedLocaleIdentifier = localeIdentifier;
++ (void)setForcedLocaleIdentifier:(NSString *)forcedLocaleIdentifier {
     if (forcedLocaleIdentifier) {
         NSLocale *forcedLocale = [[NSLocale alloc] initWithLocaleIdentifier:forcedLocaleIdentifier];
         self.sharedDateFormatter.locale = forcedLocale;


### PR DESCRIPTION
This PR refactor the code for WPDateTimeHelpers to use system functionality for relative dates instead of manual coding the strings.

