### PR TITLE
Fix search bar inset issues

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -185,6 +185,11 @@
 @property (nonatomic, copy, nonnull) NSArray<id<WPMediaAsset>> *selectedAssets;
 
 /**
+ A boolean value that determines whether the controller is presented as a popover.
+ */
+@property (nonatomic, assign, getter=isPresentedAsPopover) BOOL presentedAsPopover;
+
+/**
   The object that acts as the data source of the media picker.
  */
 @property (nonatomic, weak, nullable) id<WPMediaCollectionDataSource> dataSource;

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -185,11 +185,6 @@
 @property (nonatomic, copy, nonnull) NSArray<id<WPMediaAsset>> *selectedAssets;
 
 /**
- A boolean value that determines whether the controller is presented as a popover.
- */
-@property (nonatomic, assign, getter=isPresentedAsPopover) BOOL presentedAsPopover;
-
-/**
   The object that acts as the data source of the media picker.
  */
 @property (nonatomic, weak, nullable) id<WPMediaCollectionDataSource> dataSource;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -92,6 +92,8 @@ static CGFloat SelectAnimationTime = 0.2;
     [self.refreshControl addTarget:self action:@selector(pullToRefresh:) forControlEvents:UIControlEventValueChanged];
     [self.collectionView addSubview:self.refreshControl];
 
+    self.popoverPresentationController.delegate = self;
+
     // Setup subviews
     [self addCollectionViewToView];
     [self setupCollectionView];
@@ -993,9 +995,14 @@ referenceSizeForFooterInSection:(NSInteger)section
 
 #pragma mark - Keyboard Handling
 
+- (BOOL)shouldHandleKeyboard
+{
+    return !([self.parentViewController isKindOfClass:[WPInputMediaPickerViewController class]] || self.isPresentedAsPopover);
+}
+
 - (void)registerForKeyboardNotifications
 {
-    if (![self.parentViewController isKindOfClass:[WPInputMediaPickerViewController class]]) {
+    if ([self shouldHandleKeyboard]) {
         [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(keyboardWillShowNotification:) name:UIKeyboardWillShowNotification object:nil];
         [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(keyboardWillHideNotification:) name:UIKeyboardWillHideNotification object:nil];
     }
@@ -1003,7 +1010,7 @@ referenceSizeForFooterInSection:(NSInteger)section
 
 - (void)unregisterForKeyboardNotifications
 {
-    if (![self.parentViewController isKindOfClass:[WPInputMediaPickerViewController class]]) {
+    if ([self shouldHandleKeyboard]) {
         [NSNotificationCenter.defaultCenter removeObserver:self name:UIKeyboardWillShowNotification object:nil];
         [NSNotificationCenter.defaultCenter removeObserver:self name:UIKeyboardWillHideNotification object:nil];
     }
@@ -1130,6 +1137,13 @@ referenceSizeForFooterInSection:(NSInteger)section
 - (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar
 {
     [searchBar resignFirstResponder];
+}
+
+#pragma mark - UIPopoverPresentationControllerDelegate
+
+-(void)prepareForPopoverPresentation:(UIPopoverPresentationController *)popoverPresentationController
+{
+    self.presentedAsPopover = YES;
 }
 
 @end

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -288,13 +288,6 @@ static NSString *const ArrowDown = @"\u25be";
     }
 }
 
-#pragma mark - UIPopoverPresentationControllerDelegate
-
--(void)prepareForPopoverPresentation:(UIPopoverPresentationController *)popoverPresentationController
-{
-    self.mediaPicker.presentedAsPopover = YES;
-}
-
 #pragma mark - Public Methods
 
 - (void)showAfterViewController:(UIViewController *)viewController

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -53,8 +53,7 @@ static NSString *const ArrowDown = @"\u25be";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-
-    self.popoverPresentationController.delegate = self;
+    
     self.view.backgroundColor = [UIColor whiteColor];
 
     [self setupNavigationController];

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -54,6 +54,7 @@ static NSString *const ArrowDown = @"\u25be";
 {
     [super viewDidLoad];
 
+    self.popoverPresentationController.delegate = self;
     self.view.backgroundColor = [UIColor whiteColor];
 
     [self setupNavigationController];
@@ -285,6 +286,13 @@ static NSString *const ArrowDown = @"\u25be";
     if (viewController == self.mediaPicker || viewController == self.groupViewController) {
         [self updateSelectionAction];
     }
+}
+
+#pragma mark - UIPopoverPresentationControllerDelegate
+
+-(void)prepareForPopoverPresentation:(UIPopoverPresentationController *)popoverPresentationController
+{
+    self.mediaPicker.presentedAsPopover = YES;
 }
 
 #pragma mark - Public Methods


### PR DESCRIPTION
This PR fixes some issues with the picker content inset (and scroll indicator inset) when the keyboard is shown or hidden.
It also makes the picker view and search bar use the full width in the landscape mode on iPhone X.
Finally, a small fix was added to the initializer of the `WPMediaPickerViewController` to avoid a crash.

Fixes #264 

To test:

- Build and run the demo app.
- Present the picker and show the keyboard by tapping on the search bar.
- Scroll until the last element.
- The last element and the scroll indicator should be completely visible.
- Cancel the search to dismiss the keyboard.
- The last element should still be completely visible.

![img_1927](https://user-images.githubusercontent.com/9772967/32693826-000eb77e-c710-11e7-9403-c18807c115bf.PNG)
All this should also work in the presence of tab bars (opaque and translucent).

Test iPhone X spaces:
- On the iPhone X in landscape mode, the search bar and the scroll view background should use the full width of the screen.

<img width="707" alt="screen shot 2017-11-11 at 6 36 22 pm" src="https://user-images.githubusercontent.com/9772967/32693834-42aa327a-c710-11e7-9d3c-0b96953cc12d.png">

