### PR TITLE
Added extra API needed to know about specific events related to the search bar

### DIFF
--- a/Pod/Classes/WPMediaCollectionDataSource.h
+++ b/Pod/Classes/WPMediaCollectionDataSource.h
@@ -326,5 +326,10 @@ typedef int32_t WPMediaRequestID;
  */
 - (void)searchFor:(nullable NSString *)searchText;
 
+/**
+ *  Tells the Data Source that the search was cancelled by the user
+ */
+- (void)searchCancelled;
+
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -165,6 +165,26 @@
  */
 - (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker willShowOverlayView:(nonnull UIView *)overlayView forCellForAsset:(nonnull id<WPMediaAsset>)asset;
 
+/**
+ *  Gives the delegate an oportunity to react to a change in the number
+ *  of assets displayed as a consequence of a search filter.
+ *
+ *  @param assetCount The new asset count after a search filter is performed.
+ */
+- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker didUpdateSearchWithAssetCount:(NSInteger)assetCount;
+
+/**
+ *  Asks the delegate for an empty view to show when there are no assets
+ *  to be displayed. If no empty view is required, you have to implement this
+ *  method and return `nil`.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @return An empty view to display or `nil` to not display any.
+ *
+ *  If this method is not implemented, a default UILabel will be displayed.
+ */
+- (nullable UIView *)emptyViewForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
+
 @end
 
 
@@ -251,6 +271,21 @@
  return `YES` from `mediaPickerController:shouldShowOverlayViewForCellForAsset:`
  */
 - (void)registerClassForReusableCellOverlayViews:(nonnull Class)overlayClass;
+
+/**
+ Shows the search bar that was hidden by `hideSearchBar`. If the
+ `showSearchBar` option is set to `NO`, and the data source does not implement
+ `searchFor:`, this method will do nothing.
+ 
+ @see hideSearchBar
+ */
+- (void)showSearchBar;
+
+
+/**
+ Hides the presented search bar.
+ */
+- (void)hideSearchBar;
 
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -17,8 +17,6 @@ static CGFloat const IPadPortraitWidth = 768.0f;
 static CGFloat const IPadLandscapeWidth = 1024.0f;
 static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 
-static NSString * const kDefaultEmptyText = @"Nothing to show";
-
 @interface WPMediaPickerViewController ()
 <
  UICollectionViewDataSource,
@@ -433,7 +431,7 @@ static CGFloat SelectAnimationTime = 0.2;
 - (UIView *)defaultEmptyView
 {
     UILabel *emptyLabel = [[UILabel alloc] init];
-    emptyLabel.text = kDefaultEmptyText;
+    emptyLabel.text = NSLocalizedString(@"Nothing to show", @"Default message for empty media picker");
     [emptyLabel sizeToFit];
     return emptyLabel;
 }


### PR DESCRIPTION
Fixes #267 

After testing the implementation of the new search bar in the main WPiOS app I realized it was necessary to add five extra methods to match the actual behavior of this search bar to that of the one in the media library. 

This PR adds these extra methods:

- `searchCancelled` method in the data source to clean search states. 
Used to clean search queries in MediaLibraryPickerDataSource and re-fetch data.

- `didUpdateSearchWithAssetCount:` method in the media picker delegate.
Used to refresh the empty view state.

- `emptyViewForMediaPickerController:` method in the media picker delegate.
Used to display the `WPNoResultsView`. The media picker library also manages the empty view center animation when the keyboard appears / disappears.

- `showSearchBar` / `hideSearchBar` methods in `WPMediaPickerViewController`.
Used to show / hide the search bar when necessary.

Here is a gif that shows this implementation working in WPiOS
It also shows the search bar implemented in the editor picker with the default empty view:

![nov-16-2017 23-28-14](https://user-images.githubusercontent.com/9772967/32928828-c7d63540-cb32-11e7-99d3-5c18aca449a5.gif)

Since the current implementation of the `WPPHAssetDataSource` doesn’t have a proper support for search yet, it’s not possible to test this new implementation graphically in the demo app as it is now.

Needs review: @SergioEstevao 