### PR TITLE
WPMediaPickerViewController: Reconfigure (don't reload) cells on update

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -411,8 +411,10 @@ static CGFloat SelectAnimationTime = 0.2;
         }
     } completion:^(BOOL finished) {
         [self.collectionView performBatchUpdates:^{
-            if (changed) {
-                [self.collectionView reloadItemsAtIndexPaths:[self indexPathsFromIndexSet:changed section:0]];
+            NSArray<NSIndexPath *> *indexPaths = [self indexPathsFromIndexSet:changed section:0];
+            for (NSIndexPath *indexPath in indexPaths) {
+                WPMediaCollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
+                [self configureCell:cell forIndexPath:indexPath];
             }
             for (id<WPMediaMove> move in moves) {
                 [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:[move from] inSection:0]
@@ -602,10 +604,17 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    id<WPMediaAsset> asset = [self assetForPosition:indexPath];
     WPMediaCollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:NSStringFromClass([WPMediaCollectionViewCell class]) forIndexPath:indexPath];
 
-    // Configure the cell
+    [self configureCell:cell forIndexPath:indexPath];
+
+    return cell;
+}
+
+- (void)configureCell:(WPMediaCollectionViewCell *)cell forIndexPath:(NSIndexPath *)indexPath
+{
+    id<WPMediaAsset> asset = [self assetForPosition:indexPath];
+
     cell.asset = asset;
     NSUInteger position = [self positionOfAssetInSelection:asset];
     cell.hiddenSelectionIndicator = !self.options.allowMultipleSelection;
@@ -621,8 +630,6 @@ static CGFloat SelectAnimationTime = 0.2;
         [cell setPosition:NSNotFound];
         cell.selected = NO;
     }
-
-    return cell;
 }
 
 - (void)configureOverlayViewForCell:(WPMediaCollectionViewCell *)cell


### PR DESCRIPTION
This PR updates the change handling in `WPMediaPickerViewController` to match Apple's [sample code](https://developer.apple.com/documentation/coredata/nsfetchedresultscontrollerdelegate) for fetched results controller changes. Instead of reloading cells whenever their associated objects change, we just fetch the existing cell and update its contents. This prevents the collection view recreating cells entirely, which is useful when updating upload progress in WPiOS.

To test:

* Build and run, and ensure that cells update correctly when their contents change – it may be easiest to use this branch from WPiOS, and try uploading some items.
