### PR TITLE
Adding new picker delegate methods to WPNavigationMediaPickerViewController.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -221,6 +221,11 @@
 @property (nonatomic, strong, readonly, nullable) UISearchBar *searchBar;
 
 /**
+ The default empty view. When `emptyViewForMediaPickerController:` is not implemented, use this property to style the mensaje.
+ */
+@property (nonatomic, strong, readonly, nonnull) UILabel *defaultEmptyView;
+
+/**
  Allows to set a group as the current display group on the data source. 
  */
 - (void)setGroup:(nonnull id<WPMediaGroup>)group;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -47,6 +47,7 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 @property (nonatomic, strong) NSLayoutConstraint *searchBarTopConstraint;
 
 @property (nonatomic, strong) UIView *emptyView;
+@property (nonatomic, strong) UILabel *defaultEmptyView;
 
 /**
  The size of the camera preview cell
@@ -96,6 +97,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
     // Setup subviews
     [self addCollectionViewToView];
+    [self addEmptyViewToView];
     [self setupCollectionView];
     [self setupSearchBar];
     [self setupLayout];
@@ -420,20 +422,26 @@ static CGFloat SelectAnimationTime = 0.2;
         _emptyView = [self defaultEmptyView];
     }
 
-    if (_emptyView) {
-        [self.collectionView addSubview:_emptyView];
-        _emptyView.center = self.collectionView.center;
-    }
-
     return _emptyView;
 }
 
-- (UIView *)defaultEmptyView
+- (void)addEmptyViewToView
 {
-    UILabel *emptyLabel = [[UILabel alloc] init];
-    emptyLabel.text = NSLocalizedString(@"Nothing to show", @"Default message for empty media picker");
-    [emptyLabel sizeToFit];
-    return emptyLabel;
+    if (self.emptyView.superview == nil) {
+        [self.collectionView addSubview:_emptyView];
+        [self centerEmptyView];
+    }
+}
+
+- (UILabel *)defaultEmptyView
+{
+    if (_defaultEmptyView) {
+        return _defaultEmptyView;
+    }
+    _defaultEmptyView = [[UILabel alloc] init];
+    _defaultEmptyView.text = NSLocalizedString(@"Nothing to show", @"Default message for empty media picker");
+    [_defaultEmptyView sizeToFit];
+    return _defaultEmptyView;
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -156,6 +156,19 @@ static NSString *const ArrowDown = @"\u25be";
 
 #pragma mark - WPMediaPickerViewControllerDelegate
 
+- (void)mediaPickerController:(WPMediaPickerViewController *)picker didUpdateSearchWithAssetCount:(NSInteger)assetCount {
+    if ([self.delegate respondsToSelector:@selector(mediaPickerController:didUpdateSearchWithAssetCount:)]) {
+        [self.delegate mediaPickerController:picker didUpdateSearchWithAssetCount:assetCount];
+    }
+}
+
+- (UIView *)emptyViewForMediaPickerController:(WPMediaPickerViewController *)picker {
+    if ([self.delegate respondsToSelector:@selector(emptyViewForMediaPickerController:)]) {
+        return [self.delegate emptyViewForMediaPickerController:picker];
+    }
+    return picker.defaultEmptyView;
+}
+
 - (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker didFinishPickingAssets:(nonnull NSArray<WPMediaAsset> *)assets {
     if ([self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAssets:)]) {
         [self.delegate mediaPickerController:picker didFinishPickingAssets:assets];


### PR DESCRIPTION
This PR fixes an issue where the new delegate methods `didUpdateSearchWithAssetCount:` and `emptyViewForMediaPickerController:` are not called when using `WPNavigationMediaPickerViewController. delegate` property as the `WPMediaPickerViewControllerDelegate`.

Fixes #270 
