### PR TITLE
Adds support for Smart Invert accessibility option

### DIFF
--- a/Pod/Classes/WPAssetViewController.m
+++ b/Pod/Classes/WPAssetViewController.m
@@ -103,6 +103,9 @@
     _imageView.backgroundColor = [UIColor blackColor];
     _imageView.userInteractionEnabled = YES;
     [_imageView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapOnAsset:)]];
+    if (@available(iOS 11.0, *)) {
+        _imageView.accessibilityIgnoresInvertColors = YES;
+    }
     return _imageView;
 }
 

--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -80,6 +80,9 @@ static const CGFloat LabelRegularFontSize = 13;
     _imageView.contentMode = UIViewContentModeScaleAspectFill;
     _imageView.clipsToBounds = YES;
     _imageView.backgroundColor = self.backgroundColor;
+    if (@available(iOS 11.0, *)) {
+        _imageView.accessibilityIgnoresInvertColors = YES;
+    }
     self.backgroundView = _imageView;
 
     _selectionFrame = [[UIView alloc] initWithFrame:self.backgroundView.frame];

--- a/Pod/Classes/WPMediaGroupTableViewCell.m
+++ b/Pod/Classes/WPMediaGroupTableViewCell.m
@@ -21,6 +21,9 @@ static CGFloat const WPMediaGroupTableViewCellCountLabelMargin = 2.0;
     _imagePosterView.clipsToBounds = YES;
     _imagePosterView.translatesAutoresizingMaskIntoConstraints = NO;
     _imagePosterView.backgroundColor = _posterBackgroundColor;
+    if (@available(iOS 11.0, *)) {
+        _imagePosterView.accessibilityIgnoresInvertColors = YES;
+    }
     [self.contentView addSubview:_imagePosterView];
     
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];

--- a/Pod/Classes/WPVideoPlayerView.m
+++ b/Pod/Classes/WPVideoPlayerView.m
@@ -54,6 +54,10 @@ static CGFloat toolbarHeight = 44;
     self.timeObserver = [self.player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(1, NSEC_PER_SEC) queue:nil usingBlock:^(CMTime time) {
         [weakSelf updateVideoDuration];
     }];
+
+    if (@available(iOS 11.0, *)) {
+        self.accessibilityIgnoresInvertColors = YES;
+    }
 }
 
 - (void)dealloc {


### PR DESCRIPTION
iOS 11 introduces a new accessibility feature called 'Smart Invert Colors'. This is like the old 'invert colors' feature, but can exclude specific content from being inverted – instead it's displayed slightly dimmed or desaturated.

This PR sets image views within MediaPicker-iOS that display photographic content so they're not inverted when Smart Invert Colors is enabled. Unfortunately the feature doesn't screenshot correctly (the entire UI is inverted, not just the images), but this gives you a rough idea of what the PR fixes:

![smart-invert](https://user-images.githubusercontent.com/4780/33070542-42898c62-ceb0-11e7-8406-c13f16df1df7.png)

To test:

* On an iOS 11 device, enable Smart Invert Colors – go into Settings > General > Accessibility > Display Accommodations > Invert Colors > turn on Smart Invert.
* View the groups list, the collection view inside a group, and the asset preview for a single asset. Ensure that their colours aren't inverted.