### PR TITLE
Video player: Toolbar / home indicator fixes for iPhone X

### DIFF
--- a/Pod/Classes/WPAssetViewController.m
+++ b/Pod/Classes/WPAssetViewController.m
@@ -201,16 +201,29 @@
     }
 }
 
-- (BOOL)prefersStatusBarHidden {
+- (BOOL)prefersStatusBarHidden
+{
+    return self.videoView.controlToolbarHidden;
+}
+
+- (BOOL)prefersHomeIndicatorAutoHidden
+{
     return self.videoView.controlToolbarHidden;
 }
 
 - (void)handleTapOnAsset:(UIGestureRecognizer *)gestureRecognizer
 {
     if (gestureRecognizer.state == UIGestureRecognizerStateEnded) {
-        [self.navigationController setNavigationBarHidden:!self.videoView.controlToolbarHidden animated:YES];
-        [self.videoView setControlToolbarHidden: !self.videoView.controlToolbarHidden animated: YES];
-        [self setNeedsStatusBarAppearanceUpdate];
+        BOOL hidden = !self.videoView.controlToolbarHidden;
+        [self.navigationController setNavigationBarHidden:hidden animated:YES];
+        __weak __typeof(self) weakSelf = self;
+        [self.videoView setControlToolbarHidden:hidden animated:YES completion:^{
+            [weakSelf setNeedsStatusBarAppearanceUpdate];
+
+            if (@available(iOS 11.0, *)) {
+                [weakSelf setNeedsUpdateOfHomeIndicatorAutoHidden];
+            }
+        }];
     }
 }
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -70,6 +70,11 @@ static NSString *const ArrowDown = @"\u25be";
     return self.internalNavigationController.topViewController;
 }
 
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden
+{
+    return self.internalNavigationController.topViewController;
+}
+
 - (void)setupNavigationController
 {
     if (!self.dataSource) {

--- a/Pod/Classes/WPVideoPlayerView.h
+++ b/Pod/Classes/WPVideoPlayerView.h
@@ -28,7 +28,7 @@
 @property (nonatomic, assign) BOOL shouldAutoPlay;
 
 - (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated;
-- (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated completion:(void(^)())completion;
+- (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated completion:(void(^)(void))completion;
 
 @property (nonatomic, readonly) UIToolbar *controlToolbar;
 

--- a/Pod/Classes/WPVideoPlayerView.h
+++ b/Pod/Classes/WPVideoPlayerView.h
@@ -28,6 +28,7 @@
 @property (nonatomic, assign) BOOL shouldAutoPlay;
 
 - (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated;
+- (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated completion:(void(^)())completion;
 
 @property (nonatomic, readonly) UIToolbar *controlToolbar;
 

--- a/Pod/Classes/WPVideoPlayerView.m
+++ b/Pod/Classes/WPVideoPlayerView.m
@@ -181,17 +181,17 @@ static CGFloat toolbarHeight = 44;
                        completion:nil];
 }
 
-- (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated completion:(void(^)())completion
+- (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated completion:(void(^)(void))completion
 {
     CGFloat animationDuration = animated ? UINavigationControllerHideShowBarDuration : 0;
 
     __weak __typeof(self) weakSelf = self;
 
-    void (^updateBlock)() = ^{
+    void (^updateBlock)(void) = ^{
         [weakSelf updateToolbarPosition:hidden];
     };
 
-    void (^completionBlock)() = ^{
+    void (^completionBlock)(void) = ^{
         weakSelf.controlToolbar.hidden = hidden;
         if (completion) {
             completion();

--- a/Pod/Classes/WPVideoPlayerView.m
+++ b/Pod/Classes/WPVideoPlayerView.m
@@ -68,8 +68,8 @@ static CGFloat toolbarHeight = 44;
 - (void)layoutSubviews {
     [super layoutSubviews];
     self.playerLayer.frame = self.bounds;
-    CGFloat position = self.controlToolbarHidden ? 0 : toolbarHeight;
-    self.controlToolbar.frame = CGRectMake(0, self.frame.size.height - position, self.frame.size.width, toolbarHeight);
+
+    [self updateToolbarPosition:self.controlToolbarHidden];
 }
 
 - (UIToolbar *)controlToolbar {
@@ -176,16 +176,55 @@ static CGFloat toolbarHeight = 44;
 }
 
 - (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated {
+    [self setControlToolbarHidden:hidden
+                         animated:animated
+                       completion:nil];
+}
+
+- (void)setControlToolbarHidden:(BOOL)hidden animated:(BOOL)animated completion:(void(^)())completion
+{
     CGFloat animationDuration = animated ? UINavigationControllerHideShowBarDuration : 0;
+
+    __weak __typeof(self) weakSelf = self;
+
+    void (^updateBlock)() = ^{
+        [weakSelf updateToolbarPosition:hidden];
+    };
+
+    void (^completionBlock)() = ^{
+        weakSelf.controlToolbar.hidden = hidden;
+        if (completion) {
+            completion();
+        }
+    };
+
+    if (!animated) {
+        updateBlock();
+        completionBlock();
+        return;
+    }
+
     if (!hidden) {
+        // Unhide before animating appearance
         self.controlToolbar.hidden = hidden;
     }
-    [UIView animateWithDuration:animationDuration animations:^{
-        CGFloat position = hidden ? 0 : self.controlToolbar.frame.size.height;
-        self.controlToolbar.frame = CGRectMake(0, self.frame.size.height - position, self.frame.size.width, toolbarHeight);
-    } completion:^(BOOL finished) {
-        self.controlToolbar.hidden = hidden;
+
+    [UIView animateWithDuration:animationDuration
+                     animations:updateBlock
+                     completion:^(BOOL finished) {
+        completionBlock();
     }];
+}
+
+- (void)updateToolbarPosition:(BOOL)hidden
+{
+    CGFloat height = toolbarHeight;
+    if (@available(iOS 11.0, *)) {
+        height += self.safeAreaInsets.bottom;
+    }
+
+    CGFloat position = hidden ? 0 : height;
+    self.controlToolbar.frame = CGRectMake(0, self.frame.size.height - position, self.frame.size.width, toolbarHeight);
 }
 
 - (void)setControlToolbarHidden:(BOOL)hidden {
@@ -199,6 +238,7 @@ static CGFloat toolbarHeight = 44;
 - (void)updateControlToolbar {
     [self updateControlToolbarVideoEnded:NO];
 }
+
 - (void)updateControlToolbarVideoEnded:(BOOL)videoEnded{
     UIBarButtonSystemItem playPauseButton = [self.player timeControlStatus] == AVPlayerTimeControlStatusPaused || videoEnded ? UIBarButtonSystemItemPlay : UIBarButtonSystemItemPause;
 


### PR DESCRIPTION
This PR makes a few tweaks to the toolbar in the video player to better support iPhone X.

* The home indicator no longer overlaps the toolbar
* The home indicator is now hidden automatically when the toolbar is hidden

![picker-video](https://user-images.githubusercontent.com/4780/33082460-c4af79a8-ced4-11e7-8c5f-86639005439b.png)

To test:

* In the demo app on iPhone X, open the picker and find a video. Open the video detail by 3D touching / long pressing on the video thumbnail.
* Tap to show the toolbar.
* Ensure that the toolbar controls sit above the home indicator in both orientations.
* Tap the screen again to hide the toolbar. Ensure the the home indicator is hidden after a brief delay.
* Tap again to show the toolbar, and ensure that the home indicator re-appears.
* Ensure that it still looks right on a non-iPhone X device, and that it doesn't crash on iOS 10.