### PR TITLE
Update MediaPicker to version 0.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9
+osx_image: xcode9.2
 sudo: false
 language: objective-c
 podfile: Example/Podfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 `WPMediaPicker` adheres to [Semantic Versioning](http://semver.org/).
 
 #### 0.x Releases
+- `0.26` Release  - [0.26](#26)
 - `0.25` Release  - [0.25](#25)
 - `0.24` Release  - [0.24](#24)
 - `0.23` Release  - [0.23](#23)
@@ -14,6 +15,18 @@ All notable changes to this project will be documented in this file.
 - `0.17` Releases - [0.17](#17)
 - `0.16` Releases - [0.16](#16)
 - `0.15` Releases - [0.15](#15)
+
+---
+## [0.26](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.26)
+Released on 2010-01-10. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.26).
+
+### Added
+- Smar Invert support. #272
+
+### Fixed
+- Fix video player on iPhone X. #273
+- Center empty view. #274
 
 ---
 ## [0.25](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.25)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (0.24)
+  - WPMediaPicker (0.26)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 5e2db7fd30d8ca497d91b26fbf61e94d6660f1c6
+  WPMediaPicker: 847c1f84f93fda7dda8cc9a8cbc1ffb6e47dea63
 
 PODFILE CHECKSUM: 7c47e10b39aca62b1f30c3c4260cc99456cf95f8
 

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "0.25"
+  s.version          = "0.26"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Prepares release 0.26

To test:
 - Check if the following files are updated correctly:
  - README.md
  - CHANGELOG.md
  - WPMediaPicker.podspec

