### PR TITLE
Fix crash when dealloc WPMediaGroupCell with _changesObserver = nil

### DIFF
--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -22,7 +22,9 @@ static CGFloat const WPMediaGroupCellHeight = 86.0f;
 
 - (void)dealloc
 {
-    [_dataSource unregisterChangeObserver:_changesObserver];
+    if (_changesObserver) {
+        [_dataSource unregisterChangeObserver:_changesObserver];
+    }
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION

This PR is a small fix of a bug I found while working in StockPhotos for the WP-iOS app.

This crash happens when a `WPNavigationMediaPickerViewController` instance is presented and never showing the `WPMediaGroupPickerViewController` in screen.

In this way, `WPMediaGroupPickerViewController.viewDidLoad` is never called and the `changesObserver` is never created, but it still tries to unregister it.

Probably in Obj-C this wasn't much of a problem, but bringing it to Swift, that `nil` becomes a crash.

To reproduce this issue, it is explained in the StockPhotos PR [here.](https://github.com/wordpress-mobile/WordPress-iOS/pull/8985)

