### PR TITLE
Implement a carousel view to preview multiple selection of assets

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -212,7 +212,7 @@
 
     WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:assets];
     carouselVC.assetViewDelegate = picker;
-    [carouselVC setIndex:selected animated:NO];
+    [carouselVC setPreviewingAssetAtIndex:selected animated:NO];
     return carouselVC;
 }
 

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -202,20 +202,20 @@
     [self.mediaPicker showAfterViewController:postProcessingViewController];
 }
 
-- (UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAsset:(id<WPMediaAsset>)asset {
-    if (asset.assetType == WPMediaTypeAudio) {
-        return nil;
-    }
-
-    if ([self.options[MediaPickerOptionsCustomPreview] boolValue]) {
-        return [[CustomPreviewViewController alloc] initWithAsset:asset];
-    }
-
-    WPAssetViewController *assetViewController = [[WPAssetViewController alloc] initWithAsset: asset];
-    assetViewController.delegate = picker;
-    assetViewController.selected = [picker.selectedAssets containsObject:asset];
-    return assetViewController;
-}
+//- (UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAsset:(id<WPMediaAsset>)asset {
+//    if (asset.assetType == WPMediaTypeAudio) {
+//        return nil;
+//    }
+//
+//    if ([self.options[MediaPickerOptionsCustomPreview] boolValue]) {
+//        return [[CustomPreviewViewController alloc] initWithAsset:asset];
+//    }
+//
+//    WPAssetViewController *assetViewController = [[WPAssetViewController alloc] initWithAsset: asset];
+//    assetViewController.delegate = picker;
+//    assetViewController.selected = [picker.selectedAssets containsObject:asset];
+//    return assetViewController;
+//}
 
 - (BOOL)mediaPickerController:(WPMediaPickerViewController *)picker shouldShowOverlayViewForCellForAsset:(id<WPMediaAsset>)asset
 {

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -202,20 +202,19 @@
     [self.mediaPicker showAfterViewController:postProcessingViewController];
 }
 
-//- (UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAsset:(id<WPMediaAsset>)asset {
-//    if (asset.assetType == WPMediaTypeAudio) {
-//        return nil;
-//    }
-//
-//    if ([self.options[MediaPickerOptionsCustomPreview] boolValue]) {
-//        return [[CustomPreviewViewController alloc] initWithAsset:asset];
-//    }
-//
-//    WPAssetViewController *assetViewController = [[WPAssetViewController alloc] initWithAsset: asset];
-//    assetViewController.delegate = picker;
-//    assetViewController.selected = [picker.selectedAssets containsObject:asset];
-//    return assetViewController;
-//}
+- (UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAssets:(NSArray<id<WPMediaAsset>> *)assets selectedIndex:(NSInteger)selected
+{
+
+    if ([self.options[MediaPickerOptionsCustomPreview] boolValue]) {
+        id<WPMediaAsset> asset = assets[selected];
+        return [[CustomPreviewViewController alloc] initWithAsset:asset];
+    }
+
+    WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:assets];
+    carouselVC.assetViewDelegate = picker;
+    [carouselVC setIndex:selected animated:NO];
+    return carouselVC;
+}
 
 - (BOOL)mediaPickerController:(WPMediaPickerViewController *)picker shouldShowOverlayViewForCellForAsset:(id<WPMediaAsset>)asset
 {

--- a/Pod/Classes/WPCarouselAssetsViewController.h
+++ b/Pod/Classes/WPCarouselAssetsViewController.h
@@ -1,9 +1,16 @@
 #import <UIKit/UIKit.h>
 #import "WPMediaCollectionDataSource.h"
+#import "WPAssetViewController.h"
 
 @interface WPCarouselAssetsViewController : UIPageViewController
 
+NS_ASSUME_NONNULL_BEGIN
+
+@property (nonatomic, weak, nullable) id<WPAssetViewControllerDelegate> assetViewDelegate;
+
 - (instancetype)initWithAssets:(NSArray<id<WPMediaAsset>> *)assets;
 - (void)setIndex:(NSInteger)index animated:(BOOL)animated;
+
+NS_ASSUME_NONNULL_END
 
 @end

--- a/Pod/Classes/WPCarouselAssetsViewController.h
+++ b/Pod/Classes/WPCarouselAssetsViewController.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+#import "WPMediaCollectionDataSource.h"
+
+@interface WPCarouselAssetsViewController : UIPageViewController
+
+- (instancetype)initWithAssets:(NSArray<id<WPMediaAsset>> *)assets;
+- (void)setIndex:(NSInteger)index animated:(BOOL)animated;
+
+@end

--- a/Pod/Classes/WPCarouselAssetsViewController.h
+++ b/Pod/Classes/WPCarouselAssetsViewController.h
@@ -8,8 +8,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, nullable) id<WPAssetViewControllerDelegate> assetViewDelegate;
 
+
+/**
+ Init a WPCarouselAssetsViewController with the list of assets to preview.
+
+ @param assets An array of assets to show in the carousel preview.
+ @return an initiated WPCarouselAssetsViewController.
+ */
 - (instancetype)initWithAssets:(NSArray<id<WPMediaAsset>> *)assets;
-- (void)setIndex:(NSInteger)index animated:(BOOL)animated;
+
+
+/**
+ Set a new asset as the presenting asset in the carousel preview
+
+ @param index Index of the asset to present
+ @param animated Should the change be animated?
+ */
+- (void)setPreviewingAssetAtIndex:(NSInteger)index animated:(BOOL)animated;
 
 NS_ASSUME_NONNULL_END
 

--- a/Pod/Classes/WPCarouselAssetsViewController.m
+++ b/Pod/Classes/WPCarouselAssetsViewController.m
@@ -28,7 +28,7 @@
     [self updateTitle];
 }
 
-- (void)setIndex:(NSInteger)index animated:(BOOL)animated
+- (void)setPreviewingAssetAtIndex:(NSInteger)index animated:(BOOL)animated
 {
     self.index = index;
     if (self.isViewLoaded) {
@@ -100,8 +100,9 @@
 
 - (void)updateTitle
 {
-    NSString *separator = NSLocalizedString(@"of", @"Word separating the current index of the total amount. I.e.: 7 of 9");
-    self.title = [NSString stringWithFormat:@"%ld %@ %ld", self.index + 1, separator, self.assets.count];
+    NSString *separator = NSLocalizedString(@"of", @"Word separating the current index from the total amount. I.e.: 7 of 9");
+    long showingCount = self.index + 1;
+    self.title = [NSString stringWithFormat:@"%ld %@ %ld", showingCount, separator, (long)self.assets.count];
 }
 
 - (NSInteger)indexForViewController:(UIViewController *)viewController

--- a/Pod/Classes/WPCarouselAssetsViewController.m
+++ b/Pod/Classes/WPCarouselAssetsViewController.m
@@ -37,7 +37,7 @@
     }
 }
 
-#pragma mark: - UIPageViewControllerDelegate
+#pragma mark - UIPageViewControllerDelegate
 
 - (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerBeforeViewController:(UIViewController *)viewController
 {
@@ -57,7 +57,7 @@
     return [self viewControllerAtIndex:index + 1];
 }
 
-#pragma mark: - UIPageViewControllerDelegate
+#pragma mark - UIPageViewControllerDelegate
 
 - (void)pageViewController:(UIPageViewController *)pageViewController didFinishAnimating:(BOOL)finished previousViewControllers:(NSArray<UIViewController *> *)previousViewControllers transitionCompleted:(BOOL)completed
 {
@@ -73,7 +73,7 @@
     self.nextIndex = [self indexForViewController:nextViewController];
 }
 
-#pragma mark: - WPAssetViewControllerDelegate
+#pragma mark - WPAssetViewControllerDelegate
 
 - (void)assetViewController:(nonnull WPAssetViewController *)assetPreviewVC failedWithError:(nonnull NSError *)error {
     if (self.assetViewDelegate) {
@@ -87,7 +87,7 @@
     }
 }
 
-#pragma mark: - Helpers
+#pragma mark - Helpers
 
 - (void)initialSetup
 {
@@ -121,7 +121,6 @@
     id<WPMediaAsset> asset = [self.assets objectAtIndex:index];
     WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
     fullScreenImageVC.asset = asset;
-    //    fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
     fullScreenImageVC.delegate = self;
     return fullScreenImageVC;
 }

--- a/Pod/Classes/WPCarouselAssetsViewController.m
+++ b/Pod/Classes/WPCarouselAssetsViewController.m
@@ -1,7 +1,6 @@
 #import "WPCarouselAssetsViewController.h"
-#import "WPAssetViewController.h"
 
-@interface WPCarouselAssetsViewController () <UIPageViewControllerDataSource, UIPageViewControllerDelegate>
+@interface WPCarouselAssetsViewController () <UIPageViewControllerDataSource, UIPageViewControllerDelegate, WPAssetViewControllerDelegate>
 @property (nonatomic, strong) NSArray<id<WPMediaAsset>> *assets;
 @property (assign, nonatomic) NSInteger index;
 @property (assign, nonatomic) NSInteger nextIndex;
@@ -74,6 +73,20 @@
     self.nextIndex = [self indexForViewController:nextViewController];
 }
 
+#pragma mark: - WPAssetViewControllerDelegate
+
+- (void)assetViewController:(nonnull WPAssetViewController *)assetPreviewVC failedWithError:(nonnull NSError *)error {
+    if (self.assetViewDelegate) {
+        [self.assetViewDelegate assetViewController:assetPreviewVC failedWithError:error];
+    }
+}
+
+- (void)assetViewController:(nonnull WPAssetViewController *)assetPreviewVC selectionChanged:(BOOL)selected {
+    if (self.assetViewDelegate) {
+        [self.assetViewDelegate assetViewController:assetPreviewVC selectionChanged:selected];
+    }
+}
+
 #pragma mark: - Helpers
 
 - (void)initialSetup
@@ -108,7 +121,7 @@
     WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
     fullScreenImageVC.asset = asset;
     //    fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
-    //    fullScreenImageVC.delegate = self;
+    fullScreenImageVC.delegate = self;
     return fullScreenImageVC;
 }
 

--- a/Pod/Classes/WPCarouselAssetsViewController.m
+++ b/Pod/Classes/WPCarouselAssetsViewController.m
@@ -1,0 +1,121 @@
+#import "WPCarouselAssetsViewController.h"
+#import "WPAssetViewController.h"
+
+@interface WPCarouselAssetsViewController () <UIPageViewControllerDataSource, UIPageViewControllerDelegate>
+@property (nonatomic, strong) NSArray<id<WPMediaAsset>> *assets;
+@property (assign, nonatomic) NSInteger index;
+@property (assign, nonatomic) NSInteger nextIndex;
+@end
+
+@implementation WPCarouselAssetsViewController
+
+- (instancetype)initWithAssets:(NSArray<id<WPMediaAsset>> *)assets
+{
+    NSDictionary *options = @{UIPageViewControllerOptionInterPageSpacingKey : @20};
+    self = [super initWithTransitionStyle:UIPageViewControllerTransitionStyleScroll
+                    navigationOrientation:UIPageViewControllerNavigationOrientationHorizontal
+                                  options:options];
+    if (self) {
+        _assets = assets;
+    }
+
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    [self initialSetup];
+    [self updateTitle];
+}
+
+- (void)setIndex:(NSInteger)index animated:(BOOL)animated
+{
+    self.index = index;
+    if (self.isViewLoaded) {
+        UIViewController *newViewController = [self viewControllerAtIndex:index];
+        [self setViewController:newViewController animated:animated];
+    }
+}
+
+#pragma mark: - UIPageViewControllerDelegate
+
+- (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerBeforeViewController:(UIViewController *)viewController
+{
+    NSInteger index = [self indexForViewController:viewController];
+    if (index == 0) {
+        return nil;
+    }
+    return [self viewControllerAtIndex:index - 1];
+}
+
+- (nullable UIViewController *)pageViewController:(nonnull UIPageViewController *)pageViewController viewControllerAfterViewController:(nonnull UIViewController *)viewController
+{
+    NSInteger index = [self indexForViewController:viewController];
+    if (index == self.assets.count - 1) {
+        return nil;
+    }
+    return [self viewControllerAtIndex:index + 1];
+}
+
+#pragma mark: - UIPageViewControllerDelegate
+
+- (void)pageViewController:(UIPageViewController *)pageViewController didFinishAnimating:(BOOL)finished previousViewControllers:(NSArray<UIViewController *> *)previousViewControllers transitionCompleted:(BOOL)completed
+{
+    if (completed) {
+        self.index = self.nextIndex;
+        [self updateTitle];
+    }
+}
+
+- (void)pageViewController:(UIPageViewController *)pageViewController willTransitionToViewControllers:(NSArray<UIViewController *> *)pendingViewControllers
+{
+    UIViewController *nextViewController = pendingViewControllers.firstObject;
+    self.nextIndex = [self indexForViewController:nextViewController];
+}
+
+#pragma mark: - Helpers
+
+- (void)initialSetup
+{
+    self.view.backgroundColor = [UIColor blackColor];
+    self.dataSource = self;
+    self.delegate = self;
+    UIViewController *initialVC = [self viewControllerAtIndex:self.index];
+    [self setViewController:initialVC animated:NO];
+}
+
+- (void)updateTitle
+{
+    NSString *separator = NSLocalizedString(@"of", @"Word separating the current index of the total amount. I.e.: 7 of 9");
+    self.title = [NSString stringWithFormat:@"%ld %@ %ld", self.index + 1, separator, self.assets.count];
+}
+
+- (NSInteger)indexForViewController:(UIViewController *)viewController
+{
+    if (![viewController isKindOfClass:[WPAssetViewController class]]) {
+        NSAssert(NO, @"Pages need to be of class `WPAssetViewController`");
+        return 0;
+    }
+    WPAssetViewController *assetController = (WPAssetViewController *)viewController;
+    id<WPMediaAsset> asset = assetController.asset;
+    return [self.assets indexOfObject:asset];
+}
+
+- (UIViewController *)viewControllerAtIndex:(NSInteger)index
+{
+    id<WPMediaAsset> asset = [self.assets objectAtIndex:index];
+    WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
+    fullScreenImageVC.asset = asset;
+    //    fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
+    //    fullScreenImageVC.delegate = self;
+    return fullScreenImageVC;
+}
+
+- (void)setViewController:(UIViewController *)viewController animated:(BOOL)animated
+{
+    NSArray<UIViewController *> *viewControllers = [NSArray arrayWithObject:viewController];
+    [self setViewControllers:viewControllers direction:UIPageViewControllerNavigationDirectionForward animated:animated completion:nil];
+}
+
+@end

--- a/Pod/Classes/WPMediaPicker.h
+++ b/Pod/Classes/WPMediaPicker.h
@@ -1,6 +1,7 @@
 #ifndef _WPMEDIAPICKER_
 
 #import "WPAssetViewController.h"
+#import "WPCarouselAssetsViewController.h"
 #import "WPIndexMove.h"
 #import "WPInputMediaPickerViewController.h"
 #import "WPMediaCapturePreviewCollectionView.h"

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -121,6 +121,7 @@
 - (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker selectionChanged:(nonnull NSArray<id<WPMediaAsset>> *)assets;
 
 /**
+ *  DEPRECATED: Use `mediaPickerController:previewViewControllerForAssets:selectedIndex`
  *  Asks the delegate for a view controller to push when previewing the specified asset.
  *  If this method isn't implemented, the default view controller will be used.
  *  If it returns nil, no preview will be displayed.
@@ -128,9 +129,17 @@
  *  @param picker The controller object managing the assets picker interface.
  *  @param asset  The asset to be previewed.
  */
-- (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset;
+- (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset DEPRECATED_ATTRIBUTE;
 
-
+/**
+ *  Asks the delegate for a view controller to push when previewing the selected assets.
+ *  If this method isn't implemented, the default view controller will be used.
+ *  If it returns nil, no preview will be displayed.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @param assets The selected assets.
+ *  @param selected Index of asset tapped by the user to begin the preview
+ */
 - (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAssets:(nonnull NSArray<id<WPMediaAsset>> *)assets selectedIndex:(NSInteger)selected;
 
 /**

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -130,6 +130,9 @@
  */
 - (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset;
 
+
+- (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAssets:(nonnull NSArray<id<WPMediaAsset>> *)assets selectedIndex:(NSInteger)selected;
+
 /**
  *  Tells the delegate that the picker will begin requesting
  *  new data from its data source.

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -1015,25 +1015,41 @@ referenceSizeForFooterInSection:(NSInteger)section
                                  previewViewControllerForAsset:asset];
     }
 
-
-
     return [self defaultPreviewViewControllerForAsset:asset];
 }
 
-- (UIViewController *)defaultPreviewViewControllerForAsset:(id <WPMediaAsset>)asset
+- (nonnull UIViewController *)defaultPreviewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset
+{
+    if (self.selectedAssets.count <= 1 || [self.selectedAssets indexOfObject:asset] == NSNotFound) {
+        return [self singleAssetPreviewViewController:asset];
+    } else {
+        return [self multipleAssetPreviewViewControllerForSelectedAsset:asset];
+    }
+}
+
+- (UIViewController *)singleAssetPreviewViewController:(id <WPMediaAsset>)asset
 {
     // We can't preview PHAssets that are audio files
     if ([self.dataSource isKindOfClass:[WPPHAssetDataSource class]] && asset.assetType == WPMediaTypeAudio) {
         return nil;
     }
 
-//    WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
-//    fullScreenImageVC.asset = asset;
-//    fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
-//    fullScreenImageVC.delegate = self;
-//    return fullScreenImageVC;
+    WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
+    fullScreenImageVC.asset = asset;
+    fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
+    fullScreenImageVC.delegate = self;
+    return fullScreenImageVC;
+}
+
+- (UIViewController *)multipleAssetPreviewViewControllerForSelectedAsset:(id <WPMediaAsset>)asset
+{
+    // We can't preview PHAssets that are audio files
+    if ([self.dataSource isKindOfClass:[WPPHAssetDataSource class]] && asset.assetType == WPMediaTypeAudio) {
+        return nil;
+    }
 
     WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:self.selectedAssets];
+    carouselVC.assetViewDelegate = self;
     NSInteger index = [self.selectedAssets indexOfObject:asset];
     [carouselVC setIndex:index animated:NO];
     return carouselVC;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -1071,7 +1071,7 @@ referenceSizeForFooterInSection:(NSInteger)section
 
     WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:selectedAssets];
     carouselVC.assetViewDelegate = self;
-    [carouselVC setIndex:index animated:NO];
+    [carouselVC setPreviewingAssetAtIndex:index animated:NO];
     return carouselVC;
 }
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -6,6 +6,7 @@
 #import "WPPHAssetDataSource.h"
 #import "WPMediaCapturePresenter.h"
 #import "WPInputMediaPickerViewController.h"
+#import "WPCarouselAssetsViewController.h"
 
 @import MobileCoreServices;
 @import AVFoundation;
@@ -1014,6 +1015,8 @@ referenceSizeForFooterInSection:(NSInteger)section
                                  previewViewControllerForAsset:asset];
     }
 
+
+
     return [self defaultPreviewViewControllerForAsset:asset];
 }
 
@@ -1024,11 +1027,16 @@ referenceSizeForFooterInSection:(NSInteger)section
         return nil;
     }
 
-    WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
-    fullScreenImageVC.asset = asset;
-    fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
-    fullScreenImageVC.delegate = self;
-    return fullScreenImageVC;
+//    WPAssetViewController *fullScreenImageVC = [[WPAssetViewController alloc] init];
+//    fullScreenImageVC.asset = asset;
+//    fullScreenImageVC.selected = [self positionOfAssetInSelection:asset] != NSNotFound;
+//    fullScreenImageVC.delegate = self;
+//    return fullScreenImageVC;
+
+    WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:self.selectedAssets];
+    NSInteger index = [self.selectedAssets indexOfObject:asset];
+    [carouselVC setIndex:index animated:NO];
+    return carouselVC;
 }
 
 - (void)displayPreviewController:(UIViewController *)viewController {

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -1054,12 +1054,20 @@ referenceSizeForFooterInSection:(NSInteger)section
 - (UIViewController *)multipleAssetPreviewViewControllerForSelectedAsset:(id <WPMediaAsset>)asset
 {
     NSArray *selectedAssets = self.selectedAssets.copy;
-    NSInteger index = [selectedAssets indexOfObject:asset];
 
     // We can't preview PHAssets that are audio files
     if ([self.dataSource isKindOfClass:[WPPHAssetDataSource class]]) {
+        if (asset.assetType == WPMediaTypeAudio) {
+            return nil;
+        }
+
         selectedAssets = [self selectedAssetsByRemovingAudioAssets];
+        if (selectedAssets.count == 0) {
+            return nil;
+        }
     }
+
+    NSInteger index = [selectedAssets indexOfObject:asset];
 
     WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:selectedAssets];
     carouselVC.assetViewDelegate = self;

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -246,12 +246,12 @@ static NSString *const ArrowDown = @"\u25be";
     }
 }
 
-- (nullable UIViewController *)mediaPickerController:(nonnull WPMediaPickerViewController *)picker previewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset {
-    if ([self.delegate respondsToSelector:@selector(mediaPickerController:previewViewControllerForAsset:)]) {
-        return [self.delegate mediaPickerController:picker previewViewControllerForAsset:asset];
+- (nullable UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAssets:(nonnull NSArray<id<WPMediaAsset>> *)assets selectedIndex:(NSInteger)selected {
+    if ([self.delegate respondsToSelector:@selector(mediaPickerController:previewViewControllerForAssets:selectedIndex:)]) {
+        return [self.delegate mediaPickerController:picker previewViewControllerForAssets:assets selectedIndex:selected];
     }
 
-    return [self.mediaPicker defaultPreviewViewControllerForAsset:asset];
+    return [self.mediaPicker defaultPreviewViewControllerForAsset:assets[selected]];
 }
 
 - (void)mediaPickerControllerWillBeginLoadingData:(nonnull WPMediaPickerViewController *)picker {


### PR DESCRIPTION
This PR adds implements a carousel assets view to preview assets selected under multiple selection.

The [original design](https://user-images.githubusercontent.com/2722505/37941996-994ad1ea-31a3-11e8-9660-19badea57e28.jpg) was made for Stock Photos, and the original issue can be found [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/8954).

Work In progress:

- [x] Implement base pagination
- [x] Reconnect delegates
- [x] Add multiple / single preview option to sample project
- [x] Documentation

To test:
1. Open the picker.
2. Select multiple assets.
3. Open preview via force touch (or long press in the Input view).
4. Scroll and see all your assets.
