### PR TITLE
Bottom action bar

### DIFF
--- a/Example/WPMediaPicker/AppDelegate.m
+++ b/Example/WPMediaPicker/AppDelegate.m
@@ -13,6 +13,9 @@
     // Customize appearance
     self.window.tintColor = [UIColor colorWithRed:0/255.0f green:135/255.0f blue:190/255.0f alpha:1.0f];
     self.window.backgroundColor = [UIColor whiteColor];
+
+    //Configure bottom action bar line color
+    [[WPActionBar appearance] setLineColor:[UIColor colorWithRed:0.91 green:0.94 blue:0.95 alpha:1.0]];
     
     //Configure navigation bar background color
     [[UINavigationBar appearance] setBarTintColor:[UIColor colorWithRed:0/255.0f green:135/255.0f blue:190/255.0f alpha:1.0f]];

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -255,7 +255,6 @@
     self.pickerDataSource = [WPPHAssetDataSource sharedInstance];
     self.mediaPicker.dataSource = self.pickerDataSource;
     self.mediaPicker.selectionActionTitle = NSLocalizedString(@"Insert %@", @"");
-    self.mediaPicker.mediaPicker.actionBar.lineColor = [UIColor colorWithRed:0.91 green:0.94 blue:0.95 alpha:1.0];
 
     if (self.mediaInputViewController) {
         self.mediaPicker.mediaPicker.selectedAssets = self.mediaInputViewController.mediaPicker.selectedAssets;

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -204,7 +204,6 @@
 
 - (UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAssets:(NSArray<id<WPMediaAsset>> *)assets selectedIndex:(NSInteger)selected
 {
-
     if ([self.options[MediaPickerOptionsCustomPreview] boolValue]) {
         id<WPMediaAsset> asset = assets[selected];
         return [[CustomPreviewViewController alloc] initWithAsset:asset];
@@ -256,6 +255,7 @@
     self.pickerDataSource = [WPPHAssetDataSource sharedInstance];
     self.mediaPicker.dataSource = self.pickerDataSource;
     self.mediaPicker.selectionActionTitle = NSLocalizedString(@"Insert %@", @"");
+
     if (self.mediaInputViewController) {
         self.mediaPicker.mediaPicker.selectedAssets = self.mediaInputViewController.mediaPicker.selectedAssets;
         self.mediaInputViewController.mediaPicker.selectedAssets = [NSArray<WPMediaAsset> new];

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -255,6 +255,7 @@
     self.pickerDataSource = [WPPHAssetDataSource sharedInstance];
     self.mediaPicker.dataSource = self.pickerDataSource;
     self.mediaPicker.selectionActionTitle = NSLocalizedString(@"Insert %@", @"");
+    self.mediaPicker.mediaPicker.actionBar.lineColor = [UIColor colorWithRed:0.91 green:0.94 blue:0.95 alpha:1.0];
 
     if (self.mediaInputViewController) {
         self.mediaPicker.mediaPicker.selectedAssets = self.mediaInputViewController.mediaPicker.selectedAssets;

--- a/Pod/Classes/WPActionBar.h
+++ b/Pod/Classes/WPActionBar.h
@@ -5,7 +5,7 @@
 /**
  The color for the top horizontal line.
  */
-@property (nonatomic, strong) UIColor *lineColor;
+@property (nonatomic, strong) UIColor *lineColor UI_APPEARANCE_SELECTOR;
 
 /**
  Adds the given button to the left side of the bar

--- a/Pod/Classes/WPActionBar.h
+++ b/Pod/Classes/WPActionBar.h
@@ -1,0 +1,31 @@
+//
+//  WPActionBar.h
+//  WPMediaPicker
+//
+//  Created by Eduardo Toledo on 4/5/18.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface WPActionBar : UIView
+
+/**
+ The color for the top horizontal line.
+ */
+@property (nonatomic, strong) UIColor *lineColor;
+
+/**
+ Adds the given button to the left side of the bar
+
+ @param button The button to add.
+ */
+- (void)addLeftButton:(UIButton *)button;
+
+/**
+ Adds the given button to the right side of the bar
+
+ @param button The button to add.
+ */
+- (void)addRightButton:(UIButton *)button;
+
+@end

--- a/Pod/Classes/WPActionBar.h
+++ b/Pod/Classes/WPActionBar.h
@@ -1,10 +1,3 @@
-//
-//  WPActionBar.h
-//  WPMediaPicker
-//
-//  Created by Eduardo Toledo on 4/5/18.
-//
-
 #import <UIKit/UIKit.h>
 
 @interface WPActionBar : UIView

--- a/Pod/Classes/WPActionBar.m
+++ b/Pod/Classes/WPActionBar.m
@@ -1,0 +1,128 @@
+#import "WPActionBar.h"
+
+static const CGFloat SeparatorLineHeight = 2.f;
+static const CGFloat BarMinimumHeight = 44.f;
+static const UIEdgeInsets ButtonsBarEdgeInsets = {0, 20, 0, 20}; //top, left, bottom, right
+
+@interface WPActionBar()
+@property (nonatomic, strong) UIStackView *stackView;
+@property (nonatomic, strong) UIView *lineView;
+@end
+
+@implementation WPActionBar
+
+- (instancetype)init
+{
+    if (self = [super initWithFrame:CGRectZero]) {
+        [self setup];
+    }
+    return self;
+}
+
+- (void)setup
+{
+    [self setupView];
+    [self setupStackView];
+    [self setupConstraints];
+}
+
+- (void)setupView
+{
+    [self setBackgroundColor:[UIColor whiteColor]];
+    [self setAutoresizingMask:(UIViewAutoresizingFlexibleHeight)];
+    [self addSubview:[self lineView]];
+}
+
+- (void)setupStackView
+{
+    [self.stackView setAxis:UILayoutConstraintAxisHorizontal];
+    [self.stackView setAlignment:UIStackViewAlignmentFill];
+    [self.stackView setDistribution:UIStackViewDistributionFill];
+    [self.stackView setTranslatesAutoresizingMaskIntoConstraints:NO];
+
+    [self.stackView addArrangedSubview:[self separatorView]];
+    [self.stackView setLayoutMargins:ButtonsBarEdgeInsets];
+    [self.stackView setLayoutMarginsRelativeArrangement:YES];
+
+    [self addSubview:self.stackView];
+}
+
+- (UIView *)separatorView
+{
+    UIView *view = [UIView new];
+    [view setTranslatesAutoresizingMaskIntoConstraints:NO];
+    [[view.heightAnchor constraintEqualToConstant:BarMinimumHeight] setActive:YES];
+    return view;
+}
+
+- (UIView *)lineView
+{
+    if (_lineView) {
+        return _lineView;
+    }
+    _lineView = [UIView new];
+    [_lineView setTranslatesAutoresizingMaskIntoConstraints:NO];
+    [[_lineView.heightAnchor constraintEqualToConstant:SeparatorLineHeight] setActive:YES];
+    [_lineView setBackgroundColor:[UIColor whiteColor]];
+    return _lineView;
+}
+
+- (CGSize)intrinsicContentSize
+{
+    // Necessary to make the iPhone X bottom inset work.
+    return CGSizeZero;
+}
+
+- (UIStackView *)stackView
+{
+    if (_stackView) {
+        return _stackView;
+    }
+    _stackView = [UIStackView new];
+    return _stackView;
+}
+
+
+#pragma mark - public methods
+
+- (UIColor *)lineColor
+{
+    return self.lineView.backgroundColor;
+}
+
+- (void)setLineColor:(UIColor *)lineColor
+{
+    [self.lineView setBackgroundColor:lineColor];
+}
+
+- (void)addLeftButton:(UIButton *)button
+{
+    [self.stackView insertArrangedSubview:button atIndex:0];
+}
+
+- (void)addRightButton:(UIButton *)button
+{
+    [self.stackView addArrangedSubview:button];
+}
+
+#pragma mark - Layout
+
+- (void)setupConstraints
+{
+    [NSLayoutConstraint activateConstraints:
+     @[
+       [self.lineView.topAnchor constraintEqualToAnchor:self.topAnchor],
+       [self.lineView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+       [self.lineView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
+    ]];
+
+    [NSLayoutConstraint activateConstraints:
+     @[
+       [self.stackView.topAnchor constraintEqualToAnchor:self.lineView.bottomAnchor],
+       [self.stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+       [self.stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+       [self.stackView.bottomAnchor constraintEqualToAnchor:self.layoutMarginsGuide.bottomAnchor]
+    ]];
+}
+
+@end

--- a/Pod/Classes/WPActionBar.m
+++ b/Pod/Classes/WPActionBar.m
@@ -29,7 +29,7 @@ static const UIEdgeInsets ButtonsBarEdgeInsets = {0, 20, 0, 20}; //top, left, bo
 - (void)setupView
 {
     [self setBackgroundColor:[UIColor whiteColor]];
-    [self setAutoresizingMask:(UIViewAutoresizingFlexibleHeight)];
+    [self setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
     [self addSubview:[self lineView]];
 }
 
@@ -75,13 +75,11 @@ static const UIEdgeInsets ButtonsBarEdgeInsets = {0, 20, 0, 20}; //top, left, bo
 
 - (UIStackView *)stackView
 {
-    if (_stackView) {
-        return _stackView;
+    if (!_stackView) {
+        _stackView = [UIStackView new];
     }
-    _stackView = [UIStackView new];
     return _stackView;
 }
-
 
 #pragma mark - public methods
 

--- a/Pod/Classes/WPMediaPicker.h
+++ b/Pod/Classes/WPMediaPicker.h
@@ -14,5 +14,6 @@
 #import "WPPHAssetDataSource.h"
 #import "WPMediaCapturePreviewCollectionView.h"
 #import "WPVideoPlayerView.h"
+#import "WPActionBar.h"
 
 #endif /* _WPMEDIAPICKER_ */

--- a/Pod/Classes/WPMediaPickerOptions.h
+++ b/Pod/Classes/WPMediaPickerOptions.h
@@ -38,4 +38,9 @@
  */
 @property (nonatomic, assign) BOOL showSearchBar;
 
+/**
+ If YES, the picker will use a bottom action bar instead of the top right action button for multiple selection. By default the value is YES.
+ */
+@property (nonatomic, assign) BOOL showActionBar;
+
 @end

--- a/Pod/Classes/WPMediaPickerOptions.m
+++ b/Pod/Classes/WPMediaPickerOptions.m
@@ -13,6 +13,7 @@
         _allowMultipleSelection = YES;
         _scrollVertically = YES;
         _showSearchBar = NO;
+        _showActionBar = YES;
     }
     return self;
 }
@@ -26,6 +27,7 @@
     options.allowMultipleSelection = self.allowMultipleSelection;
     options.scrollVertically = self.scrollVertically;
     options.showSearchBar = self.showSearchBar;
+    options.showActionBar = self.showActionBar;
 
     return options;
 }

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -238,6 +238,20 @@
 @property (nonatomic, strong, readonly, nonnull) UILabel *defaultEmptyView;
 
 /**
+ A localized string that reflect the action that will be done when the user finishes picking assets.
+ This string can contain a a placeholder for a numeric value that will indicate the number of media items selected.
+ If this is nil the default value will be used. The default the value is 'Add %@'
+ */
+@property (nonatomic, copy, nullable) NSString *selectionActionTitle;
+
+/**
+ A localized string that reflect the action that will be done when the user chooses to preview the selected assets.
+ This string can contain a a placeholder for a numeric value that will indicate the number of media items selected.
+ If this is nil the default value will be used. The default the value is 'Preview %@'
+ */
+@property (nonatomic, copy, nullable) NSString *previewActionTitle;
+
+/**
  Allows to set a group as the current display group on the data source. 
  */
 - (void)setGroup:(nonnull id<WPMediaGroup>)group;

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -2,6 +2,7 @@
 #import "WPMediaCollectionDataSource.h"
 #import "WPAssetViewController.h"
 #import "WPMediaPickerOptions.h"
+#import "WPActionBar.h"
 
 @class WPMediaPickerViewController;
 /**
@@ -250,6 +251,13 @@
  If this is nil the default value will be used. The default the value is 'Preview %@'
  */
 @property (nonatomic, copy, nullable) NSString *previewActionTitle;
+
+
+/**
+ The bottom bar used to show the action buttons.
+ Use this instance to style the bar as required, or to add extra buttons.
+ */
+@property (nonatomic, strong, readonly, nullable) WPActionBar *actionBar;
 
 /**
  Allows to set a group as the current display group on the data source. 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -398,7 +398,7 @@ static CGFloat SelectAnimationTime = 0.2;
     return [self formatButtonTitleWithTitlePlaceholder:actionString];
 }
 
--(NSString *)selectionActionTitle
+- (NSString *)selectionActionTitle
 {
     NSString *actionString = _selectionActionTitle;
     if (actionString == nil) {
@@ -439,7 +439,7 @@ static CGFloat SelectAnimationTime = 0.2;
     return [self shouldShowActionBar];
 }
 
--(UIView *)inputAccessoryView
+- (UIView *)inputAccessoryView
 {
     if ([self shouldShowActionBar]) {
         return self.accessoryActionBar;
@@ -549,7 +549,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
 #pragma mark - UICollectionViewDataSource
 
--(void)updateDataWithRemoved:(NSIndexSet *)removed inserted:(NSIndexSet *)inserted changed:(NSIndexSet *)changed moved:(NSArray<id<WPMediaMove>> *)moves {
+- (void)updateDataWithRemoved:(NSIndexSet *)removed inserted:(NSIndexSet *)inserted changed:(NSIndexSet *)changed moved:(NSArray<id<WPMediaMove>> *)moves {
     if ([removed containsIndex:self.assetIndexInPreview.item]){
         self.assetIndexInPreview = nil;
     }
@@ -582,7 +582,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
 }
 
--(NSArray *)indexPathsFromIndexSet:(NSIndexSet *)indexSet section:(NSInteger)section{
+- (NSArray *)indexPathsFromIndexSet:(NSIndexSet *)indexSet section:(NSInteger)section{
     NSMutableArray *indexPaths = [NSMutableArray arrayWithCapacity:indexSet.count];
     [indexSet enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
         [indexPaths addObject:[NSIndexPath indexPathForItem:idx inSection:section]];

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -409,10 +409,8 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (NSString *)formatButtonTitleWithTitlePlaceholder:(NSString *)placeholder
 {
-    NSNumberFormatter * numberFormatter = [[NSNumberFormatter alloc] init];
-    NSString * countString = [numberFormatter stringFromNumber:[NSNumber numberWithInteger:self.internalSelectedAssets.count]];
-    NSString * resultString = [NSString stringWithFormat:placeholder, countString];
-    return resultString;
+    NSString * countString = @(self.internalSelectedAssets.count).stringValue;
+    return [NSString stringWithFormat:placeholder, countString];
 }
 
 - (void)updateActionbar

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -385,10 +385,8 @@ static CGFloat SelectAnimationTime = 0.2;
     UIBarButtonItem *previewButton = [[UIBarButtonItem alloc] initWithTitle:self.previewActionTitle style:(UIBarButtonItemStylePlain) target:self action:@selector(onPreviewButtonPressed:)];
     UIBarButtonItem *addButton = [[UIBarButtonItem alloc] initWithTitle:self.selectionActionTitle style:(UIBarButtonItemStyleDone) target:self action:@selector(onAddButtonPressed:)];
     UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:(UIBarButtonSystemItemFlexibleSpace) target:nil action:nil];
-    UIBarButtonItem *leftFixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:(UIBarButtonSystemItemFixedSpace) target:nil action:nil];
-    UIBarButtonItem *rightFixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:(UIBarButtonSystemItemFixedSpace) target:nil action:nil];
 
-    return @[leftFixedSpace, previewButton, flexibleSpace, addButton, rightFixedSpace];
+    return @[previewButton, flexibleSpace, addButton];
 }
 
 - (NSString *)previewActionTitle

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -50,7 +50,9 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 @property (nonatomic, strong) UIView *emptyView;
 @property (nonatomic, strong) UILabel *defaultEmptyView;
 
-@property (nonatomic, strong) UIToolbar *accessoryActionBar;
+@property (nonatomic, strong) WPActionBar *accessoryActionBar;
+@property (nonatomic, strong) UIButton *selectedActionButton;
+@property (nonatomic, strong) UIButton *previewActionButton;
 
 /**
  The size of the camera preview cell
@@ -368,25 +370,51 @@ static CGFloat SelectAnimationTime = 0.2;
 
 #pragma mark - Action bar
 
-- (UIToolbar *)accessoryActionBar
+- (UIView *)actionBar
+{
+    return self.accessoryActionBar;
+}
+
+- (WPActionBar *)accessoryActionBar
 {
     if (_accessoryActionBar) {
         return _accessoryActionBar;
     }
-    _accessoryActionBar = [[UIToolbar alloc] init];
-    [_accessoryActionBar setItems:[self actionBarButtons]];
+    _accessoryActionBar = [[WPActionBar alloc] init];
+
+    [_accessoryActionBar addLeftButton:self.previewActionButton];
+    [_accessoryActionBar addRightButton:self.selectedActionButton];
     [_accessoryActionBar sizeToFit];
 
     return _accessoryActionBar;
 }
 
-- (NSArray<UIBarButtonItem *>*)actionBarButtons
+- (UIButton *)previewActionButton
 {
-    UIBarButtonItem *previewButton = [[UIBarButtonItem alloc] initWithTitle:self.previewActionTitle style:(UIBarButtonItemStylePlain) target:self action:@selector(onPreviewButtonPressed:)];
-    UIBarButtonItem *addButton = [[UIBarButtonItem alloc] initWithTitle:self.selectionActionTitle style:(UIBarButtonItemStyleDone) target:self action:@selector(onAddButtonPressed:)];
-    UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:(UIBarButtonSystemItemFlexibleSpace) target:nil action:nil];
+    if (_previewActionButton) {
+        return _previewActionButton;
+    }
 
-    return @[previewButton, flexibleSpace, addButton];
+    _previewActionButton = [UIButton buttonWithType:(UIButtonTypeSystem)];
+    [_previewActionButton addTarget:self action:@selector(onPreviewButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [_previewActionButton setTitle:self.previewActionTitle forState:UIControlStateNormal];
+
+    return _previewActionButton;
+}
+
+- (UIButton *)selectedActionButton
+{
+    if (_selectedActionButton) {
+        return _selectedActionButton;
+    }
+
+    _selectedActionButton = [UIButton buttonWithType:(UIButtonTypeSystem)];
+    UIFont *font = _selectedActionButton.titleLabel.font;
+    _selectedActionButton.titleLabel.font = [UIFont boldSystemFontOfSize:font.pointSize];
+    [_selectedActionButton addTarget:self action:@selector(onAddButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [_selectedActionButton setTitle:self.selectionActionTitle forState:UIControlStateNormal];
+
+    return _selectedActionButton;
 }
 
 - (NSString *)previewActionTitle
@@ -416,7 +444,12 @@ static CGFloat SelectAnimationTime = 0.2;
 - (void)updateActionbar
 {
     if ([self shouldShowActionBar]) {
-        [self.accessoryActionBar setItems:[self actionBarButtons]];
+        [UIView performWithoutAnimation:^{
+            [self.previewActionButton setTitle:self.previewActionTitle forState:UIControlStateNormal];
+            [self.selectedActionButton setTitle:self.selectionActionTitle forState:UIControlStateNormal];
+            [self.previewActionButton layoutIfNeeded];
+            [self.selectedActionButton layoutIfNeeded];
+        }];
 
         if ([self.searchBar isFirstResponder]) {
             [self.searchBar reloadInputViews];

--- a/Pod/Classes/WPNavigationMediaPickerViewController.h
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.h
@@ -45,6 +45,13 @@ The internal WPMediaPickerViewController that is used to display the media.
 @property (nonatomic, copy, nullable) NSString *selectionActionTitle;
 
 /**
+ A localized string that reflect the action that will be done when the user chooses to preview the selected assets.
+ This string can contain a a placeholder for a numeric value that will indicate the number of media items selected.
+ If this is nil the default value will be used. The default the value is 'Preview %@'
+ */
+@property (nonatomic, copy, nullable) NSString *previewActionTitle;
+
+/**
  If this property is set to NO the picker will not show the interface to display groups. The default value is YES.
  */
 @property (nonatomic, assign) BOOL showGroupSelector;

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -143,6 +143,18 @@ static NSString *const ArrowDown = @"\u25be";
     [self presentViewController:groupViewController animated:YES completion:nil];
 }
 
+- (void)setSelectionActionTitle:(NSString *)selectionActionTitle
+{
+    _selectionActionTitle = selectionActionTitle;
+    self.mediaPicker.selectionActionTitle = _selectionActionTitle;
+}
+
+-(void)setPreviewActionTitle:(NSString *)previewActionTitle
+{
+    _previewActionTitle = previewActionTitle;
+    self.mediaPicker.previewActionTitle = _previewActionTitle;
+}
+
 #pragma mark - WPMediaGroupViewControllerDelegate
 
 - (void)mediaGroupPickerViewController:(WPMediaGroupPickerViewController *)picker didPickGroup:(id<WPMediaGroup>)group
@@ -272,31 +284,18 @@ static NSString *const ArrowDown = @"\u25be";
         [self.delegate mediaPickerController:picker selectionChanged:assets];
     }
     [self updateSelectionAction];
-
 }
 
 - (void)updateSelectionAction {
-//    if (self.mediaPicker.selectedAssets.count == 0 || !self.mediaPicker.options.allowMultipleSelection) {
-//        self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = nil;
-//        return;
-//    }
-//    UIBarButtonItem *rightButtonItem = [[UIBarButtonItem alloc] initWithTitle:[self selectionActionValue]
-//                                                            style:UIBarButtonItemStyleDone
-//                                                           target:self
-//                                                           action:@selector(finishPicker:)];
-//    self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = rightButtonItem;
-}
-
-- (NSString *)selectionActionValue {
-    NSString *actionString = self.selectionActionTitle;
-    if (actionString == nil) {
-        actionString = NSLocalizedString(@"Select %@", @"Action for Navigation bar to indicate selection of media. The argument in the string represents the number of elements (as numeric digits) selected");
+    if (self.mediaPicker.options.showActionBar || self.mediaPicker.selectedAssets.count == 0 || !self.mediaPicker.options.allowMultipleSelection) {
+        self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = nil;
+        return;
     }
-    NSNumberFormatter * numberFormatter = [[NSNumberFormatter alloc] init];
-    NSString * countString = [numberFormatter stringFromNumber:[NSNumber numberWithInteger:self.mediaPicker.selectedAssets.count]];
-    NSString * resultString = [NSString stringWithFormat:actionString, countString];
-
-    return resultString;
+    UIBarButtonItem *rightButtonItem = [[UIBarButtonItem alloc] initWithTitle:self.mediaPicker.selectionActionTitle
+                                                            style:UIBarButtonItemStyleDone
+                                                           target:self
+                                                           action:@selector(finishPicker:)];
+    self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = rightButtonItem;
 }
 
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -276,15 +276,15 @@ static NSString *const ArrowDown = @"\u25be";
 }
 
 - (void)updateSelectionAction {
-    if (self.mediaPicker.selectedAssets.count == 0 || !self.mediaPicker.options.allowMultipleSelection) {
-        self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = nil;
-        return;
-    }
-    UIBarButtonItem *rightButtonItem = [[UIBarButtonItem alloc] initWithTitle:[self selectionActionValue]
-                                                            style:UIBarButtonItemStyleDone
-                                                           target:self
-                                                           action:@selector(finishPicker:)];
-    self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = rightButtonItem;
+//    if (self.mediaPicker.selectedAssets.count == 0 || !self.mediaPicker.options.allowMultipleSelection) {
+//        self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = nil;
+//        return;
+//    }
+//    UIBarButtonItem *rightButtonItem = [[UIBarButtonItem alloc] initWithTitle:[self selectionActionValue]
+//                                                            style:UIBarButtonItemStyleDone
+//                                                           target:self
+//                                                           action:@selector(finishPicker:)];
+//    self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = rightButtonItem;
 }
 
 - (NSString *)selectionActionValue {


### PR DESCRIPTION
This PR implements a bottom action bar to preview and insert assets selected under multiple selection.

The [original design](https://user-images.githubusercontent.com/2722505/37941996-994ad1ea-31a3-11e8-9660-19badea57e28.jpg) was made for Stock Photos, and the original issue can be found [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/8954).

- Added an option to continue using the top right button in case of any library user prefers that.
- Small changes in the use of `self.internalSelectedAssets` and `self.selectedAssets` to avoid unnecessary copy.

![bottom_bar](https://user-images.githubusercontent.com/9772967/38335909-6b13d49a-3836-11e8-9dc2-3b6ee1db4c7a.gif)


**To test:**

- Open the media picker with multiple selection.
- Play selecting, deselecting, previewing, inserting assets, showing and dismissing the keyboard.