### PR TITLE
Add switch to show action bar to the options screen.

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -245,6 +245,7 @@
     options.filter = [self.options[MediaPickerOptionsFilterType] intValue];
     options.scrollVertically = [self.options[MediaPickerOptionsScrollInputPickerVertically] boolValue];
     options.showSearchBar = [self.options[MediaPickerOptionsShowSearchBar] boolValue];
+    options.showActionBar = [self.options[MediaPickerOptionsShowActionBar] boolValue];
     return options;
 }
 

--- a/Example/WPMediaPicker/OptionsViewController.h
+++ b/Example/WPMediaPicker/OptionsViewController.h
@@ -10,6 +10,7 @@ extern NSString const *MediaPickerOptionsCustomPreview;
 extern NSString const *MediaPickerOptionsScrollInputPickerVertically;
 extern NSString const *MediaPickerOptionsShowSampleCellOverlays;
 extern NSString const *MediaPickerOptionsShowSearchBar;
+extern NSString const *MediaPickerOptionsShowActionBar;
 
 @class OptionsViewController;
 

--- a/Example/WPMediaPicker/OptionsViewController.m
+++ b/Example/WPMediaPicker/OptionsViewController.m
@@ -12,6 +12,7 @@ NSString const *MediaPickerOptionsCustomPreview = @"MediaPickerOptionsCustomPrev
 NSString const *MediaPickerOptionsScrollInputPickerVertically = @"MediaPickerOptionsScrollInputPickerVertically";
 NSString const *MediaPickerOptionsShowSampleCellOverlays = @"MediaPickerOptionsShowSampleCellOverlays";
 NSString const *MediaPickerOptionsShowSearchBar = @"MediaPickerOptionsShowSearchBar";
+NSString const *MediaPickerOptionsShowActionBar = @"MediaPickerOptionsShowActionBar";
 
 
 typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
@@ -25,6 +26,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellInputPickerScroll,
     OptionsViewControllerCellShowSampleCellOverlays,
     OptionsViewControllerCellShowSearchBar,
+    OptionsViewControllerCellShowActionBar,
     OptionsViewControllerCellTotal
 };
 
@@ -40,6 +42,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
 @property (nonatomic, strong) UITableViewCell *scrollInputPickerCell;
 @property (nonatomic, strong) UITableViewCell *cellOverlaysCell;
 @property (nonatomic, strong) UITableViewCell *showSearchBarCell;
+@property (nonatomic, strong) UITableViewCell *showActionBarCell;
 
 @end
 
@@ -111,6 +114,11 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     self.showSearchBarCell.accessoryView = [[UISwitch alloc] init];
     ((UISwitch *)self.showSearchBarCell.accessoryView).on = [self.options[MediaPickerOptionsShowSearchBar] boolValue];
     self.showSearchBarCell.textLabel.text = @"Show Search Bar";
+
+    self.showActionBarCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    self.showActionBarCell.accessoryView = [[UISwitch alloc] init];
+    ((UISwitch *)self.showActionBarCell.accessoryView).on = [self.options[MediaPickerOptionsShowActionBar] boolValue];
+    self.showActionBarCell.textLabel.text = @"Show Action Bar";
 }
 
 #pragma mark - Table view data source
@@ -156,6 +164,8 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
             return self.cellOverlaysCell;
         case OptionsViewControllerCellShowSearchBar:
             return self.showSearchBarCell;
+        case OptionsViewControllerCellShowActionBar:
+            return self.showActionBarCell;
         default:
             break;
     }
@@ -184,7 +194,8 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
              MediaPickerOptionsCustomPreview:@(((UISwitch *)self.customPreviewCell.accessoryView).on),
              MediaPickerOptionsScrollInputPickerVertically:@(((UISwitch *)self.scrollInputPickerCell.accessoryView).on),
              MediaPickerOptionsShowSampleCellOverlays:@(((UISwitch *)self.cellOverlaysCell.accessoryView).on),
-             MediaPickerOptionsShowSearchBar:@(((UISwitch *)self.showSearchBarCell.accessoryView).on)
+             MediaPickerOptionsShowSearchBar:@(((UISwitch *)self.showSearchBarCell.accessoryView).on),
+             MediaPickerOptionsShowActionBar:@(((UISwitch *)self.showActionBarCell.accessoryView).on)
              };
         
         [delegate optionsViewController:self changed:newOptions];


### PR DESCRIPTION
This PR adds an options to show/hide the action bar on the WPMediaPicker

To test:
 - Start the demo app
 - Open the options screen
 - Switch the show action bar option
 - Tap on the + button and see that all is working correctly. 

