### PR TITLE
Fix single preview on demo.

### DIFF
--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -209,10 +209,21 @@
         return [[CustomPreviewViewController alloc] initWithAsset:asset];
     }
 
-    WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:assets];
-    carouselVC.assetViewDelegate = picker;
-    [carouselVC setPreviewingAssetAtIndex:selected animated:NO];
-    return carouselVC;
+    if ([assets count] > 1) {
+        WPCarouselAssetsViewController *carouselVC = [[WPCarouselAssetsViewController alloc] initWithAssets:assets];
+        carouselVC.assetViewDelegate = picker;
+        [carouselVC setPreviewingAssetAtIndex:selected animated:NO];
+        return carouselVC;
+    } else if ([assets count] == 1){
+        id<WPMediaAsset> asset = assets[0];
+
+        WPAssetViewController *assetVC = [[WPAssetViewController alloc] initWithAsset:asset];
+        assetVC.selected = [picker.selectedAssets containsObject:asset];
+        assetVC.delegate = picker;
+        return assetVC;
+    }
+
+    return nil;
 }
 
 - (BOOL)mediaPickerController:(WPMediaPickerViewController *)picker shouldShowOverlayViewForCellForAsset:(id<WPMediaAsset>)asset


### PR DESCRIPTION
This PR make sure that in the demo app we show a single asset preview when only one asset is selected.

To test:
 - Start the demo app
 - Tap on +
 - Select  an album
 - Force touch on a asset 
 - See if a single asset preview shows correctly

