### PR TITLE
Enable bounce correctly depending of scrolling type.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -297,8 +297,8 @@ static CGFloat SelectAnimationTime = 0.2;
     self.collectionView.allowsSelection = YES;
     self.collectionView.allowsMultipleSelection = self.options.allowMultipleSelection;
     self.collectionView.bounces = YES;
-    self.collectionView.alwaysBounceHorizontal = NO;
-    self.collectionView.alwaysBounceVertical = YES;
+    self.collectionView.alwaysBounceHorizontal = !self.options.scrollVertically;
+    self.collectionView.alwaysBounceVertical = self.options.scrollVertically;
     
     // Register cell classes
     [self.collectionView registerClass:[WPMediaCollectionViewCell class]


### PR DESCRIPTION
When using horizontal scroll on full screen the collection view has allowing vertical bounce, this PR fix that.

To test:
 - Open the demo app
 - Open options
 - Disable vertical scrolling
 - Open the picker full screen
 - Select an album
 - Scroll horizontally and make sure no bounce happens vertically

