### PR TITLE
Avoid `reload data` after each search phrase change

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -116,7 +116,7 @@ static CGFloat SelectAnimationTime = 0.2;
                                 if (incrementalChanges && !weakSelf.refreshGroupFirstTime) {
                                     [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
                                 } else {
-                                    [weakSelf refreshData];
+                                    [weakSelf.collectionView reloadData];
                                 }
                             }];
 
@@ -1406,7 +1406,6 @@ referenceSizeForFooterInSection:(NSInteger)section
 {
     if ([self.dataSource respondsToSelector:@selector(searchFor:)]) {
         [self.dataSource searchFor:searchText];
-        [self.collectionView reloadData];
     }
 }
 


### PR DESCRIPTION
This PR is part of the solution for an issue found in Stock Photos [(described here)](https://github.com/wordpress-mobile/WordPress-iOS/issues/9178).

The `MediaPickerController` was reloading the collection's data each time the search phrase changed:
```objc
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
     if ([self.dataSource respondsToSelector:@selector(searchFor:)]) {
         [self.dataSource searchFor:searchText];
         [self.collectionView reloadData];  /// <- HERE
     }
 }
```

As I remember, this emulated the old search bar implementation in the Media Library, but it wasn't the best option since we don't always want to reload the whole collection view after each search phrase change (as in `Stock Photos`).

Removing that line alone fixes the `Stock Photos` [issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/9178), but it introduces a new issue where searching in the Media Library won't filter the images (won't do anything).

To fix that, we have to reload data manually in the `MediaLibraryDataSource` when search changes. But doing that by observers (notifying **non-incremental** changes) was triggering a network refresh.

Personally, if I see a `non-incremental` change, I think about `reloadData`. So I made that small change and now the MediaLibrary search works as it was working before.

```objc
    if (incrementalChanges && !weakSelf.refreshGroupFirstTime) {
        [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
    } else {
-  //  [weakSelf refreshData];
+      [weakSelf.collectionView reloadData];
    }
```

I'm not 100% sure that this change won't have other implications, but I tried to find more uses of `notifyObserversWithIncrementalChanges:NO ...` and I couldn't find anything that could be affected.

Since this is a small change but could have a big implication, I'd like to ask both of you @SergioEstevao and @frosty if you could please take a look at this 🙂

**To Test:**
I uploaded a branch in the main WPiOS project with this changes and the data source changes necessary for everything to work properly:

`issue/9178-stockphotos-reload-images-when-typing-in-searchbar`

- Checkout that branch ☝️in the main project.
- `pod install`.
- Test searching in:
    - Blog's Media Library
    - Free Photo Library (from `+` butting in the media library)
    - Editor: WordPress Media (from `W` in the style bar)
    - Editor: Free Photo Library (from `...` button in the style bar)
    - Any other media picker with search bar you could think of

