### PR TITLE
Customise title of the Cancel button

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -198,16 +198,6 @@
  */
 - (nullable UIView *)emptyViewForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 
-/**
- *  Asks the delegate for a title to be used in the Cancel button
- *
- *  @param picker The controller object managing the assets picker interface.
- *  @return The string to be used in the Cancel button, when presented enclosed in a navigation controller
- *
- *  If this method is not implemented, the title in the Cancel button will be "Cancel".
- */
-- (nonnull NSString *)cancelButtonTitleForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
-
 @end
 
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -199,14 +199,14 @@
 - (nullable UIView *)emptyViewForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 
 /**
- *  Asks the delegate for a string literal to be used in the Cancel button
+ *  Asks the delegate for a title to be used in the Cancel button
  *
  *  @param picker The controller object managing the assets picker interface.
  *  @return The string to be used in the Cancel button, when presented enclosed in a navigation controller
  *
- *  If this method is not implemented, the literal in the Cancel button will be "Cancel".
+ *  If this method is not implemented, the title in the Cancel button will be "Cancel".
  */
-- (nonnull NSString *)cancelButtonTextForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
+- (nonnull NSString *)cancelButtonTitleForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 
 @end
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -198,6 +198,16 @@
  */
 - (nullable UIView *)emptyViewForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 
+/**
+ *  Asks the delegate for a string literal to be used in the Cancel button
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @return The string to be used in the Cancel button, when presented enclosed in a navigation controller
+ *
+ *  If this method is not implemented, the literal in the Cancel button will be "Cancel".
+ */
+- (nonnull NSString *)cancelButtonTextForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
+
 @end
 
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.h
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.h
@@ -40,16 +40,22 @@ The internal WPMediaPickerViewController that is used to display the media.
 /**
  A localized string that reflect the action that will be done when the picker is selected.
  This string can contain a a placeholder for a numeric value that will indicate the number of media items selected.
- If this is nil the default value will be used. The default the value is 'Select %@'
+ If this is nil the default value will be used. The default value is 'Select %@'
  */
 @property (nonatomic, copy, nullable) NSString *selectionActionTitle;
 
 /**
  A localized string that reflect the action that will be done when the user chooses to preview the selected assets.
  This string can contain a a placeholder for a numeric value that will indicate the number of media items selected.
- If this is nil the default value will be used. The default the value is 'Preview %@'
+ If this is nil the default value will be used. The default value is 'Preview %@'
  */
 @property (nonatomic, copy, nullable) NSString *previewActionTitle;
+
+/**
+ A localized string with the title for the cancel button
+ If this is nil the default value will be used. The default value is 'Cancel'
+ */
+@property (nonatomic, copy, nullable) NSString *cancelButtonTitle;
 
 /**
  If this property is set to NO the picker will not show the interface to display groups. The default value is YES.

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -116,8 +116,8 @@ static NSString *const ArrowDown = @"\u25be";
 }
 
 - (UIBarButtonItem *)cancelButton {
-    if ([self.delegate respondsToSelector:@selector(cancelButtonTextForMediaPickerController:)]) {
-        NSString *title = [self.delegate cancelButtonTextForMediaPickerController:self.mediaPicker];
+    if ([self.delegate respondsToSelector:@selector(cancelButtonTitleForMediaPickerController:)]) {
+        NSString *title = [self.delegate cancelButtonTitleForMediaPickerController:self.mediaPicker];
         return [self cancelButtonWithTitle:title];
     } else {
         return [self defaultCancelButton];

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -95,9 +95,7 @@ static NSString *const ArrowDown = @"\u25be";
     UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController: rootController];
     nav.delegate = self;
 
-    if (!self.showGroupSelector) {
-        nav.topViewController.navigationItem.leftBarButtonItem = [self cancelButton];
-    }
+    nav.topViewController.navigationItem.leftBarButtonItem = [self cancelButton];
 
     if (self.showGroupSelector && !self.startOnGroupSelector) {
         [nav pushViewController:self.mediaPicker animated:NO];

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -114,7 +114,7 @@ static NSString *const ArrowDown = @"\u25be";
 }
 
 - (UIBarButtonItem *)cancelButton {
-    if (self.cancelButtonTitle) {
+    if (self.cancelButtonTitle && self.cancelButtonTitle.length > 0) {
         return [self cancelButtonWithTitle:self.cancelButtonTitle];
     } else {
         return [self defaultCancelButton];

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -114,9 +114,8 @@ static NSString *const ArrowDown = @"\u25be";
 }
 
 - (UIBarButtonItem *)cancelButton {
-    if ([self.delegate respondsToSelector:@selector(cancelButtonTitleForMediaPickerController:)]) {
-        NSString *title = [self.delegate cancelButtonTitleForMediaPickerController:self.mediaPicker];
-        return [self cancelButtonWithTitle:title];
+    if (self.cancelButtonTitle) {
+        return [self cancelButtonWithTitle:self.cancelButtonTitle];
     } else {
         return [self defaultCancelButton];
     }

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -96,7 +96,7 @@ static NSString *const ArrowDown = @"\u25be";
     nav.delegate = self;
 
     if (!self.showGroupSelector) {
-        nav.topViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
+        nav.topViewController.navigationItem.leftBarButtonItem = [self cancelButton];
     }
 
     if (self.showGroupSelector && !self.startOnGroupSelector) {
@@ -113,6 +113,23 @@ static NSString *const ArrowDown = @"\u25be";
     if (self.mediaPicker.options.allowMultipleSelection) {
         [self updateSelectionAction];
     }
+}
+
+- (UIBarButtonItem *)cancelButton {
+    if ([self.delegate respondsToSelector:@selector(cancelButtonTextForMediaPickerController:)]) {
+        NSString *title = [self.delegate cancelButtonTextForMediaPickerController:self.mediaPicker];
+        return [self cancelButtonWithTitle:title];
+    } else {
+        return [self defaultCancelButton];
+    }
+}
+
+- (UIBarButtonItem *)cancelButtonWithTitle:(NSString *)title {
+    return [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStylePlain target:self action:@selector(cancelPicker:)];
+}
+
+- (UIBarButtonItem *)defaultCancelButton {
+    return [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
 }
 
 - (void)cancelPicker:(UIBarButtonItem *)sender


### PR DESCRIPTION
When the media picker is presented using `WPNavigationMediaPickerViewController`, the picker is embedded in a navigation controller.

On the left hand side of that navigation controller there is a `Cancel` button, that dismisses the picker.

The button is a system button of type `UIBarButtonSystemItemCancel`.

This PR adds an optional method to `WPMediaPickerViewControllerDelegate` so that implementations of that delegate can provide a custom string for the button title. 

If that optional method is not implemented, the picker will default to the `UIBarButtonSystemItemCancel` button
