### PR TITLE
Issue/292 crashes on data source

### DIFF
--- a/Pod/Classes/WPImageExporter.m
+++ b/Pod/Classes/WPImageExporter.m
@@ -16,8 +16,8 @@
 
 + (BOOL)writeImage:(UIImage *)image withMetadata:(NSDictionary *)metadata toURL:(NSURL *)fileURL;
 {
-    NSMutableDictionary *properties = [[NSMutableDictionary alloc] initWithDictionary:@{ (NSString *)kCGImageDestinationLossyCompressionQuality: @(1)}];
-    CGImageDestinationRef destination = CGImageDestinationCreateWithURL((CFURLRef)fileURL, kUTTypeJPEG, 0.9, nil);
+    NSMutableDictionary *properties = [[NSMutableDictionary alloc] initWithDictionary:@{ (NSString *)kCGImageDestinationLossyCompressionQuality: @(0.9)}];
+    CGImageDestinationRef destination = CGImageDestinationCreateWithURL((CFURLRef)fileURL, kUTTypeJPEG, 1, nil);
     if (destination == NULL) {
         return NO;
     }

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -591,24 +591,21 @@ static CGFloat SelectAnimationTime = 0.2;
         if (inserted) {
             [self.collectionView insertItemsAtIndexPaths:[self indexPathsFromIndexSet:inserted section:0]];
         }
+        NSArray<NSIndexPath *> *indexPaths = [self indexPathsFromIndexSet:changed section:0];
+        for (NSIndexPath *indexPath in indexPaths) {
+            WPMediaCollectionViewCell *cell = (WPMediaCollectionViewCell *)[self.collectionView cellForItemAtIndexPath:indexPath];
+            [self configureCell:cell forIndexPath:indexPath];
+        }
+        for (id<WPMediaMove> move in moves) {
+            [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:[move from] inSection:0]
+                                         toIndexPath:[NSIndexPath indexPathForItem:[move to] inSection:0]];
+            if (self.assetIndexInPreview.row == move.from) {
+                self.assetIndexInPreview = [NSIndexPath indexPathForItem:move.to inSection:0];
+            }
+        }
     } completion:^(BOOL finished) {
-        [self.collectionView performBatchUpdates:^{
-            NSArray<NSIndexPath *> *indexPaths = [self indexPathsFromIndexSet:changed section:0];
-            for (NSIndexPath *indexPath in indexPaths) {
-                WPMediaCollectionViewCell *cell = (WPMediaCollectionViewCell *)[self.collectionView cellForItemAtIndexPath:indexPath];
-                [self configureCell:cell forIndexPath:indexPath];
-            }
-            for (id<WPMediaMove> move in moves) {
-                [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:[move from] inSection:0]
-                                             toIndexPath:[NSIndexPath indexPathForItem:[move to] inSection:0]];
-                if (self.assetIndexInPreview.row == move.from) {
-                    self.assetIndexInPreview = [NSIndexPath indexPathForItem:move.to inSection:0];
-                }
-            }
-        } completion:^(BOOL finished) {
-            [self refreshSelection];
-            [self.collectionView reloadItemsAtIndexPaths:self.collectionView.indexPathsForSelectedItems];
-        }];
+        [self refreshSelection];
+        [self.collectionView reloadItemsAtIndexPaths:self.collectionView.indexPathsForSelectedItems];        
     }];
 
 }


### PR DESCRIPTION
Fixes #292 

This PR tries to fix one of the main crash issues we see on the main app related to media.

After some investigation and following up some clues from @koke here: https://github.com/wordpress-mobile/WordPress-iOS/issues/8794 I decided to do some changes on the code:

- I simplified the actions on the batchUpdates call on the collectionView.
- Made sure the assets are set independent of a full refresh or not
- Made sure that the observer for data changes on the library is not invoked when a full refresh of data is going on.

I don't have a exact set step to reproduce the original crash, but please try the following scenarios

To test:
 - Open the picker 
 - Take a Photo using the inline photo capture cell
 - Switch to Photos app add new photos and delete or move photos around
 - Switch back to the demo app and see if all works
 - If you have iCloud activated try to use this app on a device that is not synced to you iCloud library and try to open iCloud albums and see if all goes ok.

Open to more tests if you have suggestions.

