### PR TITLE
Remove shadow from WPBadgeView

### DIFF
--- a/Pod/Classes/WPBadgeView.m
+++ b/Pod/Classes/WPBadgeView.m
@@ -1,8 +1,6 @@
 
 #import "WPBadgeView.h"
 
-static const CGFloat kDefaultShadowRadius = 2.f;
-static const CGFloat kDefaultShadowOpacity = 0.5f;
 static const CGFloat kDefaultCornerRadius = 6.f;
 static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
 
@@ -41,7 +39,6 @@ static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
     [self setupBlur];
     [self layoutLabel];
     [self setupStyle];
-    [self setupShadow];
 }
 
 - (void)layoutLabel
@@ -87,7 +84,7 @@ static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
     _cornerRadius = cornerRadius;
     self.blurEffectView.layer.cornerRadius = cornerRadius;
     self.blurEffectView.layer.masksToBounds = YES;
-    [self setNeedsDisplay];
+    [self setNeedsLayout];
 }
 
 #pragma mark - Helpers
@@ -98,20 +95,6 @@ static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
     self.label.textColor = UIColor.whiteColor;
     self.insets = kDefaultEdgeInsets;
     self.cornerRadius = kDefaultCornerRadius;
-}
-
-- (void)setupShadow
-{
-    self.layer.masksToBounds = NO;
-    self.layer.shadowOffset = CGSizeZero;
-    self.layer.shadowRadius = kDefaultShadowRadius;
-    self.layer.shadowOpacity = kDefaultShadowOpacity;
-}
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    self.layer.shadowPath = [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:kDefaultCornerRadius].CGPath;
 }
 
 - (void)setupBlur

--- a/Pod/Classes/WPBadgeView.m
+++ b/Pod/Classes/WPBadgeView.m
@@ -108,6 +108,12 @@ static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
     self.layer.shadowOpacity = kDefaultShadowOpacity;
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    self.layer.shadowPath = [UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:kDefaultCornerRadius].CGPath;
+}
+
 - (void)setupBlur
 {
     self.backgroundColor = [UIColor clearColor];

--- a/Pod/Classes/WPBadgeView.m
+++ b/Pod/Classes/WPBadgeView.m
@@ -76,7 +76,6 @@ static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
     self.bottomConstraint.constant = -insets.bottom;
     self.leadingConstraint.constant = insets.left;
     self.trailingConstraint.constant = -insets.right;
-    [self setNeedsLayout];
 }
 
 - (void)setCornerRadius:(CGFloat)cornerRadius
@@ -84,7 +83,6 @@ static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
     _cornerRadius = cornerRadius;
     self.blurEffectView.layer.cornerRadius = cornerRadius;
     self.blurEffectView.layer.masksToBounds = YES;
-    [self setNeedsLayout];
 }
 
 #pragma mark - Helpers

--- a/Pod/Classes/WPBadgeView.m
+++ b/Pod/Classes/WPBadgeView.m
@@ -76,6 +76,7 @@ static const UIEdgeInsets kDefaultEdgeInsets = {3.f, 6.f, 3.f, 6.f};
     self.bottomConstraint.constant = -insets.bottom;
     self.leadingConstraint.constant = insets.left;
     self.trailingConstraint.constant = -insets.right;
+    [self layoutIfNeeded];
 }
 
 - (void)setCornerRadius:(CGFloat)cornerRadius


### PR DESCRIPTION
From the comments [here](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/295#issuecomment-393595737), we decided to remove the shadow effect from `WPBadgeView`.

This PR does just that.
I decided to not keep the shadow as a optional setup for sake of simplicity.

To test:
- Make sure you have GIF images in your device media library.
- Run the app and check that the GIF badge renders correctly (and without a shadow)
