### PR TITLE
Adding support to use a View Controller for the empty view.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -253,12 +253,6 @@
 @property (nonatomic, strong, readonly, nonnull) UILabel *defaultEmptyView;
 
 /**
- The default empty view controller. When `emptyViewControllerForMediaPickerController:` is not implemented,
- use this property to style the message.
- */
-@property (nonatomic, strong, readonly, nonnull) UIViewController *defaultEmptyViewController;
-
-/**
  A localized string that reflect the action that will be done when the user finishes picking assets.
  This string can contain a a placeholder for a numeric value that will indicate the number of media items selected.
  If this is nil the default value will be used. The default the value is 'Add %@'
@@ -312,6 +306,13 @@
  @return a view controller to preview the asset
  */
 - (nonnull UIViewController *)defaultPreviewViewControllerForAsset:(nonnull id<WPMediaAsset>)asset;
+
+/**
+ Return a View Controller to present `defaultEmptyView`.
+ 
+ @return a view controller to present the empty view.
+ */
+- (UIViewController *)defaultEmptyViewController;
 
 /**
  Calculates the appropriate cell height/width given the desired number of cells per line, desired space

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -198,6 +198,19 @@
  */
 - (nullable UIView *)emptyViewForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 
+/**
+ *  Asks the delegate for an empty view to show when there are no assets
+ *  to be displayed. If no empty view is required, you have to implement this
+ *  method and return `nil`.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @return An empty view controller to display or `nil` to not display any.
+ *
+ *  If this method is not implemented, a default ViewController with a default
+ *  UILabel will be displayed.
+ */
+- (nullable UIViewController *)emptyViewControllerForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
+
 @end
 
 
@@ -234,9 +247,16 @@
 @property (nonatomic, strong, readonly, nullable) UISearchBar *searchBar;
 
 /**
- The default empty view. When `emptyViewForMediaPickerController:` is not implemented, use this property to style the mensaje.
+ The default empty view. When `emptyViewForMediaPickerController:` is not implemented,
+ use this property to style the message.
  */
 @property (nonatomic, strong, readonly, nonnull) UILabel *defaultEmptyView;
+
+/**
+ The default empty view controller. When `emptyViewControllerForMediaPickerController:` is not implemented,
+ use this property to style the message.
+ */
+@property (nonatomic, strong, readonly, nonnull) UIViewController *defaultEmptyViewController;
 
 /**
  A localized string that reflect the action that will be done when the user finishes picking assets.

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -604,6 +604,7 @@ static CGFloat SelectAnimationTime = 0.2;
         _emptyViewController.view.frame = self.collectionView.frame;
         [self addChildViewController:_emptyViewController];
         [_emptyViewController didMoveToParentViewController:self];
+        [self centerEmptyView];
     }
 }
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -637,10 +637,7 @@ static CGFloat SelectAnimationTime = 0.2;
     }
 
     _defaultEmptyViewController = [[UIViewController alloc] init];
-
-    UILabel *emptyViewLabel = [[UILabel alloc] init];
-    emptyViewLabel.text = NSLocalizedString(@"Nothing to show", @"Default message for empty media picker");
-    [emptyViewLabel sizeToFit];
+    UILabel *emptyViewLabel = self.defaultEmptyView;
     emptyViewLabel.center = _defaultEmptyViewController.view.center;
     [[_defaultEmptyViewController view] addSubview:emptyViewLabel];
 
@@ -1430,7 +1427,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     if (self.emptyViewController) {
         CGRect emptyViewFrame = [self getEmptyViewFrame];
         emptyViewFrame.origin.y -= self.searchBar.frame.size.height/2;
-        self.emptyViewController.view.frame = emptyViewFrame;
+        _emptyViewController.view.frame = emptyViewFrame;
     } else {
         self.emptyView.center = self.collectionView.center;
         self.emptyView.frame = [self getEmptyViewFrame];

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -1397,9 +1397,10 @@ referenceSizeForFooterInSection:(NSInteger)section
     self.collectionView.contentInset = contentInset;
     self.collectionView.scrollIndicatorInsets = contentInset;
 
-    [self centerEmptyView];
-
-    [self.collectionView.collectionViewLayout invalidateLayout];
+    [UIView animateWithDuration:0.2 animations:^{
+        [self centerEmptyView];
+        [self.collectionView.collectionViewLayout invalidateLayout];
+    }];
 }
 
 - (void)keyboardWillHideNotification:(NSNotification *)notification
@@ -1415,9 +1416,10 @@ referenceSizeForFooterInSection:(NSInteger)section
     self.collectionView.contentInset = contentInset;
     self.collectionView.scrollIndicatorInsets = contentInset;
 
-    [self centerEmptyView];
-
-    [self.collectionView.collectionViewLayout invalidateLayout];
+    [UIView animateWithDuration:0.2 animations:^{
+        [self centerEmptyView];
+        [self.collectionView.collectionViewLayout invalidateLayout];
+    }];
 }
 
 /**

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -697,7 +697,11 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (void)refreshDataAnimated:(BOOL)animated
 {
-    [self.refreshControl beginRefreshing];
+    // Don't show the refreshControl if emptyViewController is being displayed.
+    if (! _emptyViewController) {
+        [self.refreshControl beginRefreshing];
+    }
+
     self.collectionView.allowsSelection = NO;
     self.collectionView.allowsMultipleSelection = NO;
     self.collectionView.scrollEnabled = NO;

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -200,6 +200,13 @@ static NSString *const ArrowDown = @"\u25be";
     return picker.defaultEmptyView;
 }
 
+- (UIViewController *)emptyViewControllerForMediaPickerController:(WPMediaPickerViewController *)picker {
+    if ([self.delegate respondsToSelector:@selector(emptyViewControllerForMediaPickerController:)]) {
+        return [self.delegate emptyViewControllerForMediaPickerController:picker];
+    }
+    return picker.defaultEmptyViewController;
+}
+
 - (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker didFinishPickingAssets:(nonnull NSArray<WPMediaAsset> *)assets {
     if ([self.delegate respondsToSelector:@selector(mediaPickerController:didFinishPickingAssets:)]) {
         [self.delegate mediaPickerController:picker didFinishPickingAssets:assets];

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.1"
+  s.version          = "1.2"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/9504

This adds the ability to use a `ViewController` for the `emptyView` state, instead of just a `UIView`. Specifically because we are transitioning from `WPNoResultsView` to `NoResultsViewController` in `WordPress-iOS` .

To test:
- This can be fully testing with https://github.com/wordpress-mobile/WordPress-iOS/pull/9889, which replaces the NoResultsView for the Stock Photo Picker.
- Otherwise, just a sanity check/code review.

Hey @etoledom - it looks like you might be familiar with the `emptyView` logic. Would you mind taking a look at this? Thanks!!