### PR TITLE
Adding check for emptyViewController.

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -599,7 +599,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (void)addEmptyViewControllerToView
 {
-    if (self.emptyViewController.view.superview == nil) {
+    if (self.emptyViewController && _emptyViewController.view.superview == nil) {
         [self.collectionView addSubview:self.emptyViewController.view];
         _emptyViewController.view.frame = self.collectionView.frame;
         [self addChildViewController:_emptyViewController];

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -599,11 +599,11 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (void)addEmptyViewControllerToView
 {
-    if (self.emptyViewController && _emptyViewController.view.superview == nil) {
+    if (self.emptyViewController && self.emptyViewController.view.superview == nil) {
         [self.collectionView addSubview:self.emptyViewController.view];
-        _emptyViewController.view.frame = self.collectionView.frame;
-        [self addChildViewController:_emptyViewController];
-        [_emptyViewController didMoveToParentViewController:self];
+        self.emptyViewController.view.frame = self.collectionView.frame;
+        [self addChildViewController:self.emptyViewController];
+        [self.emptyViewController didMoveToParentViewController:self];
         [self centerEmptyView];
     }
 }

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.2"
+  s.version          = "1.3"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/9940

Since the Post Editor in WPiOS sometimes return nil for `emptyViewController`, it was crashing when attempting to add it to the view. This adds a test to ensure it actually exists before doing so.

To test:
- This can be tested with https://github.com/wordpress-mobile/WordPress-iOS/pull/9943 by verifying edit/create a post does not crash.