### PR TITLE
Attempt to fix crash in performBatchUpdates

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.3.1-beta.1)
+  - WPMediaPicker (1.3.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 8933d580aaa0655a0233c9adba0fe90232854bbb
+  WPMediaPicker: 395a7913af9870f9868f71d472bf133a29260118
 
 PODFILE CHECKSUM: 7c47e10b39aca62b1f30c3c4260cc99456cf95f8
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -56,6 +56,7 @@ static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
 @property (nonatomic, strong) WPActionBar *accessoryActionBar;
 @property (nonatomic, strong) UIButton *selectedActionButton;
 @property (nonatomic, strong) UIButton *previewActionButton;
+@property (nonatomic, assign) NSInteger numberOfAssets;
 
 /**
  The size of the camera preview cell
@@ -656,11 +657,18 @@ static CGFloat SelectAnimationTime = 0.2;
     if ([removed containsIndex:self.assetIndexInPreview.item]){
         self.assetIndexInPreview = nil;
     }
+    // In an attemopt to fix a crash that happens in performBatchUpdates we are
+    // saving the number of assets locally and updating it according to the action (insert/ remove).
+    // This value will be returned from numberOfItems delegate method to fit the updates.
+    self.numberOfAssets = self.dataSource.numberOfAssets;
+
     [self.collectionView performBatchUpdates:^{
         if (removed) {
+            self.numberOfAssets -= removed.count;
             [self.collectionView deleteItemsAtIndexPaths:[self indexPathsFromIndexSet:removed section:0]];
         }
         if (inserted) {
+            self.numberOfAssets += inserted.count;
             [self.collectionView insertItemsAtIndexPaths:[self indexPathsFromIndexSet:inserted section:0]];
         }
         NSArray<NSIndexPath *> *indexPaths = [self indexPathsFromIndexSet:changed section:0];
@@ -844,7 +852,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
 {
-    NSInteger numberOfAssets = [self.dataSource numberOfAssets];
+    NSInteger numberOfAssets = self.numberOfAssets;
 
     if (self.searchBar.text && [self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:didUpdateSearchWithAssetCount:)]) {
         [self.mediaPickerDelegate mediaPickerController:self didUpdateSearchWithAssetCount:numberOfAssets];


### PR DESCRIPTION
In performBatchUpdates we are updating a local variable that will also be returned from numberOfItems delegate method in an attempt
to return the right number of items after an update (insert or delete rows) has occurred.

Fixes [#10073](https://github.com/wordpress-mobile/WordPress-iOS/issues/10073) (maybe)

To test:
I was not able to reproduce this crash. To test:
Go to Media and add/delete items. 
Make sure it works as expected. (items are added/ deleted and not crash).
