### PR TITLE
Add a new error code to represent parental controls

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.3.1-beta.1)
+  - WPMediaPicker (1.3.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 8933d580aaa0655a0233c9adba0fe90232854bbb
+  WPMediaPicker: 395a7913af9870f9868f71d472bf133a29260118
 
 PODFILE CHECKSUM: 7c47e10b39aca62b1f30c3c4260cc99456cf95f8
 

--- a/Pod/Classes/UIViewController+MediaAdditions.h
+++ b/Pod/Classes/UIViewController+MediaAdditions.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIViewController (MediaAdditions)
+
+- (void)wpm_showAlertWithError:(NSError *)error okActionHandler:(void (^ __nullable)(UIAlertAction *action))handler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/UIViewController+MediaAdditions.m
+++ b/Pod/Classes/UIViewController+MediaAdditions.m
@@ -1,0 +1,41 @@
+#import "UIViewController+MediaAdditions.h"
+#import "WPMediaCollectionDataSource.h"
+
+@implementation UIViewController (MediaAdditions)
+
+- (void)wpm_showAlertWithError:(NSError *)error okActionHandler:(void (^ __nullable)(UIAlertAction *action))handler {
+    NSString *title = NSLocalizedString(@"Media Library", @"Title for alert when a generic error happened when loading media");
+    NSString *message = NSLocalizedString(@"There was a problem when trying to access your media. Please try again later.",  @"Explaining to the user there was an generic error accesing media.");
+    NSString *cancelText = NSLocalizedString(@"OK", "");
+    NSString *otherButtonTitle = nil;
+    if (error.domain == WPMediaPickerErrorDomain) {
+        title = NSLocalizedString(@"Media Library", @"Title for alert when access to the media library is not granted by the user");
+        if (error.code == WPMediaPickerErrorCodePermissionDenied) {
+            otherButtonTitle = NSLocalizedString(@"Open Settings", @"Go to the settings app");
+            message = NSLocalizedString(@"This app needs permission to access your device media library in order to add photos and/or video to your posts. Please change the privacy settings if you wish to allow this.",
+                                        @"Explaining to the user why the app needs access to the device media library.");
+        } else if (error.code == WPMediaPickerErrorCodeRestricted) {
+            message = NSLocalizedString(@"Your app is not authorized to access photo data possibly due to active restrictions such as parental controls. Please check your parental control settings in this device.",
+                                        @"Explaining to the user why the app needs access to the device media library.");
+        }
+    }
+    
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
+                                                                             message:message
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:cancelText
+                                                       style:UIAlertActionStyleCancel
+                                                     handler:handler];
+    [alertController addAction:okAction];
+    
+    if (otherButtonTitle) {
+        UIAlertAction *otherAction = [UIAlertAction actionWithTitle:otherButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            NSURL *settingsURL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+            [[UIApplication sharedApplication] openURL:settingsURL options:@{} completionHandler:nil];
+        }];
+        [alertController addAction:otherAction];
+    }
+    [self presentViewController:alertController animated:YES completion:nil];
+}
+
+@end

--- a/Pod/Classes/UIViewController+MediaAdditions.m
+++ b/Pod/Classes/UIViewController+MediaAdditions.m
@@ -15,7 +15,7 @@
             message = NSLocalizedString(@"This app needs permission to access your device media library in order to add photos and/or video to your posts. Please change the privacy settings if you wish to allow this.",
                                         @"Explaining to the user why the app needs access to the device media library.");
         } else if (error.code == WPMediaPickerErrorCodeRestricted) {
-            message = NSLocalizedString(@"Your app is not authorized to access photo data possibly due to active restrictions such as parental controls. Please check your parental control settings in this device.",
+            message = NSLocalizedString(@"Your app is not authorized to access media library due to active restrictions such as parental controls. Please check your parental control settings in this device.",
                                         @"Explaining to the user why the app needs access to the device media library.");
         }
     }

--- a/Pod/Classes/WPMediaCollectionDataSource.h
+++ b/Pod/Classes/WPMediaCollectionDataSource.h
@@ -11,9 +11,10 @@ typedef NS_OPTIONS(NSInteger, WPMediaType){
 static NSString * _Nonnull const WPMediaPickerErrorDomain = @"WPMediaPickerErrorDomain";
 
 typedef NS_ENUM(NSInteger, WPMediaPickerErrorCode){
-    WPMediaErrorCodePermissionsFailed,
-    WPMediaErrorCodePermissionsUnknow,
-    WPMediaErrorCodeVideoURLNotAvailable
+    WPMediaPickerErrorCodePermissionDenied,
+    WPMediaPickerErrorCodeRestricted,
+    WPMediaPickerErrorCodeUnknown,
+    WPMediaPickerErrorCodeVideoURLNotAvailable
 };
 
 @protocol WPMediaMove <NSObject>

--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -1,5 +1,6 @@
 #import "WPMediaGroupPickerViewController.h"
 #import "WPMediaGroupTableViewCell.h"
+#import "UIViewController+MediaAdditions.h"
 
 static CGFloat const WPMediaGroupCellHeight = 86.0f;
 
@@ -65,38 +66,11 @@ static CGFloat const WPMediaGroupCellHeight = 86.0f;
 - (void)showError:(NSError *)error {
     [self.refreshControl endRefreshing];
     [self.tableView reloadData];
-    NSString *title = NSLocalizedString(@"Media Library", @"Title for alert when a generic error happened when loading media");
-    NSString *message = NSLocalizedString(@"There was a problem when trying to access your media. Please try again later.",  @"Explaining to the user there was an generic error accesing media.");
-    NSString *cancelText = NSLocalizedString(@"OK", "");
-    NSString *otherButtonTitle = nil;
-    if (error.domain == WPMediaPickerErrorDomain &&
-        error.code == WPMediaErrorCodePermissionsFailed) {
-        otherButtonTitle = NSLocalizedString(@"Open Settings", @"Go to the settings app");
-        title = NSLocalizedString(@"Media Library", @"Title for alert when access to the media library is not granted by the user");
-        message = NSLocalizedString(@"This app needs permission to access your device media library in order to add photos and/or video to your posts. Please change the privacy settings if you wish to allow this.",
-                                    @"Explaining to the user why the app needs access to the device media library.");
-    }
-
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
-                                                                             message:message
-                                                                      preferredStyle:UIAlertControllerStyleAlert];
-    UIAlertAction *okAction = [UIAlertAction actionWithTitle:cancelText
-                                                       style:UIAlertActionStyleCancel
-                                                     handler:^(UIAlertAction *action) {
-                                                         if ([self.delegate respondsToSelector:@selector(mediaGroupPickerViewControllerDidCancel:)]) {
-                                                             [self.delegate mediaGroupPickerViewControllerDidCancel:self];
-                                                         }
-                                                     }];
-    [alertController addAction:okAction];
-
-    if (otherButtonTitle) {
-        UIAlertAction *otherAction = [UIAlertAction actionWithTitle:otherButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            NSURL *settingsURL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
-            [[UIApplication sharedApplication] openURL:settingsURL options:@{} completionHandler:nil];
-        }];
-        [alertController addAction:otherAction];
-    }
-    [self presentViewController:alertController animated:YES completion:nil];
+    [self wpm_showAlertWithError:error okActionHandler:^(UIAlertAction * _Nonnull action) {
+        if ([self.delegate respondsToSelector:@selector(mediaGroupPickerViewControllerDidCancel:)]) {
+            [self.delegate mediaGroupPickerViewControllerDidCancel:self];
+        }
+    }];
 }
 
 #pragma mark - UITableViewDataSource methods

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -7,6 +7,7 @@
 #import "WPMediaCapturePresenter.h"
 #import "WPInputMediaPickerViewController.h"
 #import "WPCarouselAssetsViewController.h"
+#import "UIViewController+MediaAdditions.h"
 
 @import MobileCoreServices;
 @import AVFoundation;
@@ -763,38 +764,11 @@ static CGFloat SelectAnimationTime = 0.2;
     self.collectionView.allowsSelection = YES;
     self.collectionView.scrollEnabled = YES;
     [self.collectionView reloadData];
-    NSString *title = NSLocalizedString(@"Media Library", @"Title for alert when a generic error happened when loading media");
-    NSString *message = NSLocalizedString(@"There was a problem when trying to access your media. Please try again later.",  @"Explaining to the user there was an generic error accesing media.");
-    NSString *cancelText = NSLocalizedString(@"OK", "");
-    NSString *otherButtonTitle = nil;
-    if (error.domain == WPMediaPickerErrorDomain &&
-        error.code == WPMediaErrorCodePermissionsFailed) {
-        otherButtonTitle = NSLocalizedString(@"Open Settings", @"Go to the settings app");
-        title = NSLocalizedString(@"Media Library", @"Title for alert when access to the media library is not granted by the user");
-        message = NSLocalizedString(@"This app needs permission to access your device media library in order to add photos and/or video to your posts. Please change the privacy settings if you wish to allow this.",
-                                    @"Explaining to the user why the app needs access to the device media library.");
-    }
-
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
-                                                                             message:message
-                                                                      preferredStyle:UIAlertControllerStyleAlert];
-    UIAlertAction *okAction = [UIAlertAction actionWithTitle:cancelText
-                                                       style:UIAlertActionStyleCancel
-                                                     handler:^(UIAlertAction *action) {
+    [self wpm_showAlertWithError:error okActionHandler:^(UIAlertAction * _Nonnull action) {
         if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerControllerDidCancel:)]) {
             [self.mediaPickerDelegate mediaPickerControllerDidCancel:self];
         }
     }];
-    [alertController addAction:okAction];
-
-    if (otherButtonTitle) {
-        UIAlertAction *otherAction = [UIAlertAction actionWithTitle:otherButtonTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            NSURL *settingsURL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
-            [[UIApplication sharedApplication] openURL:settingsURL options:@{} completionHandler:nil];
-        }];
-        [alertController addAction:otherAction];
-    }
-    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)setSelectedAssets:(NSArray *)selectedAssets {

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -113,10 +113,17 @@
     PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatus];
     switch (status) {
         case PHAuthorizationStatusRestricted:
+        {
+            if (failureBlock) {
+                NSError *error = [NSError errorWithDomain:WPMediaPickerErrorDomain code:WPMediaPickerErrorCodeRestricted userInfo:nil];
+                failureBlock(error);
+            }
+            return;
+        }
         case PHAuthorizationStatusDenied:
         {
             if (failureBlock) {
-                NSError *error = [NSError errorWithDomain:WPMediaPickerErrorDomain code:WPMediaErrorCodePermissionsFailed userInfo:nil];
+                NSError *error = [NSError errorWithDomain:WPMediaPickerErrorDomain code:WPMediaPickerErrorCodePermissionDenied userInfo:nil];
                 failureBlock(error);
             }
             return;

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |s|
   }
 
   s.public_header_files = 'Pod/Classes/**/*.h'
-  s.private_header_files = 'Pod/Classes/WPDateTimeHelpers.h', 'Pod/Classes/WPImageExporter.h'
+  s.private_header_files = 'Pod/Classes/WPDateTimeHelpers.h', 'Pod/Classes/WPImageExporter.h', 'Pod/Classes/UIViewController+MediaAdditions.h'
   s.frameworks = 'UIKit', 'Photos', 'AVFoundation', 'ImageIO'
 end


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/MediaPicker-iOS/issues/310

This change adds new error code corresponding to PHAuthorizationStatusRestricted. 

Other than that Typo on the `WPMediaErrorCodePermissionsUnknow` is fixed.

And the enum naming is updated due to conventions(WPMediaPickerErrorCode+...) this will provide better translation to Swift in the future.

**To test:**

Follow steps on [parent PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10782).

