### PR TITLE
Remove Travis CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.17
+  ios: wordpress-mobile/ios@0.0.22
 
 workflows:
   test_and_validate:

--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ DerivedData
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
-# Note: if you ignore the Pods directory, make sure to uncomment
-# `pod install` in .travis.yml
 #
 Pods/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-osx_image: xcode10
-sudo: false
-language: objective-c
-podfile: Example/Podfile
-before_script:
-- cd Example && pod install && cd -
-script:
-- set -o pipefail && xcodebuild build test -workspace Example/WPMediaPicker.xcworkspace -scheme WPMediaPicker-Example -sdk iphonesimulator  -destination "name=iPhone 7" ONLY_ACTIVE_ARCH=NO | xcpretty -c


### PR DESCRIPTION
This removes the Travis config and does some related cleanup.

To test:

- CircleCI checks are still green
