### PR TITLE
Issue/10073 crash on batch changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 `WPMediaPicker` adheres to [Semantic Versioning](http://semver.org/).
 
 #### Releases
+- `1.3.4` Release  - [1.3.4](#1.3.4)
 - `1.3` Release  - [1.3](#1.3)
 - `1.2` Release  - [1.2](#1.2)
 - `1.1` Release  - [1.1](#1.1)
@@ -21,6 +22,13 @@ All notable changes to this project will be documented in this file.
 - `0.17` Releases - [0.17](#17)
 - `0.16` Releases - [0.16](#16)
 - `0.15` Releases - [0.15](#15)
+
+---
+## [1.3.4](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.3.4)
+Released on 2019-04-24. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.3.4).
+
+### Fixed
+- If no details of the changes are made available on PHDataSource send a change notification with the proper variable state set. Make sure observers are removed and readded when datasource changes. #305 #321
 
 ---
 ## [1.3](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.3)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.3.3)
+  - WPMediaPicker (1.3.4)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 6d23120b16c0f66987fd98ec2b294864e1df03bf
+  WPMediaPicker: 771f5cc7c7c6ed83c0a08182ed2770973a1e95d9
 
 PODFILE CHECKSUM: 7c47e10b39aca62b1f30c3c4260cc99456cf95f8
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -75,7 +75,7 @@
 
         if (!groupChangeDetails && !assetsChangeDetails && !albumChangeDetails) {
             [self.observers enumerateKeysAndObjectsUsingBlock:^(NSUUID *key, WPMediaChangesBlock block, BOOL *stop) {
-                block(true, [NSIndexSet new], [NSIndexSet new], [NSIndexSet new], @[]);
+                block(false, [NSIndexSet new], [NSIndexSet new], [NSIndexSet new], @[]);
             }];
             return;
         }

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.3.3"
+  s.version          = "1.3.4"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/10073 #305 

This PR makes to changes to the codebase:
 - Makes sure we send a NO to the change observer block when no incrementalChanges are detected.
 - Make sure we removed the previous observers when changing dataSources.
 
To test:
 - Open the demo app
 - Press on the + icon
 - Check if photos shows correctly
 - Switch to the Photos App, and add new assets to it or remove some
 - Switch to the Demo app and see if updates happen correctly
 - Test on the device and simulator


 @frosty Can you test with your massive iCloud library? :)

