### PR TITLE
Improve group changes notifications

### DIFF
--- a/Pod/Classes/WPMediaCollectionDataSource.h
+++ b/Pod/Classes/WPMediaCollectionDataSource.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, WPMediaLoadOptions){
 
 @protocol WPMediaAsset;
 
+typedef void (^WPMediaGroupChangesBlock)(void);
 typedef void (^WPMediaChangesBlock)(BOOL incrementalChanges, NSIndexSet * _Nonnull removed, NSIndexSet * _Nonnull inserted, NSIndexSet * _Nonnull changed, NSArray<id<WPMediaMove>> * _Nonnull moves);
 typedef void (^WPMediaSuccessBlock)(void);
 typedef void (^WPMediaFailureBlock)(NSError * _Nullable error);
@@ -255,12 +256,32 @@ typedef int32_t WPMediaRequestID;
 - (nonnull id<NSObject>)registerChangeObserverBlock:(nonnull WPMediaChangesBlock)callback;
 
 /**
+ *  Asks the data source to be notify about changes on the media library group/albums using the given callback block.
+ *
+ *  @discussion the callback object is retained by the data source so it needs to
+ * be unregistered on the end to avoid leaks or retain cycles.
+ *
+ *  @param callback a WPMediaGroupChangessBlock that is invoked every time a change is detected.
+ *
+ *  @return an opaque object that identifies the callback register. This should be used to later unregister the block
+ */
+- (nonnull id<NSObject>)registerGroupChangeObserverBlock:(nonnull WPMediaGroupChangesBlock)callback;
+
+/**
  *  Asks the data source to unregister the block that is identified by the block key.
  *
  *  @param blockKey the unique identifier of the block. This must have been obtained 
- * by a call to registerChangesObserverBlock
+ * by a call to registerChangeObserverBlock
  */
 - (void)unregisterChangeObserver:(nonnull id<NSObject>)blockKey;
+
+/**
+ *  Asks the data source to unregister the group observer block that is identified by the block key.
+ *
+ *  @param blockKey the unique identifier of the block. This must have been obtained
+ * by a call to registerGroupChangesObserverBlock
+ */
+- (void)unregisterGroupChangeObserver:(nonnull id<NSObject>)blockKey;
 
 /**
  *  Asks the data source to reload the data available of the media library. This should be invoked after changing the 

--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -23,9 +23,7 @@ static CGFloat const WPMediaGroupCellHeight = 86.0f;
 
 - (void)dealloc
 {
-    if (_changesObserver) {
-        [_dataSource unregisterChangeObserver:_changesObserver];
-    }
+    [self unregisterDataSourceObservers];
 }
 
 - (void)viewDidLoad
@@ -43,11 +41,30 @@ static CGFloat const WPMediaGroupCellHeight = 86.0f;
 
     //Setup navigation
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];
-    __weak __typeof__(self) weakSelf = self;
-    self.changesObserver = [self.dataSource registerChangeObserverBlock:^(BOOL incrementalChanges, NSIndexSet *deleted, NSIndexSet *inserted, NSIndexSet *reload, NSArray *moves) {
-            [weakSelf loadData];            
-        }];
+
     [self loadData];
+}
+
+- (void)setDataSource:(id<WPMediaCollectionDataSource>)dataSource {
+    [self unregisterDataSourceObservers];
+    _dataSource = dataSource;
+    [self registerDataSourceObservers];
+}
+
+- (void)registerDataSourceObservers {
+    __weak __typeof__(self) weakSelf = self;
+    self.changesObserver = [self.dataSource registerGroupChangeObserverBlock:^() {
+        if (weakSelf.isViewLoaded) {
+            [weakSelf loadData];
+        }
+    }];
+}
+
+- (void)unregisterDataSourceObservers {
+    if (_changesObserver) {
+        [_dataSource unregisterGroupChangeObserver:_changesObserver];
+        _changesObserver = nil;
+    }
 }
 
 - (void)loadData


### PR DESCRIPTION
Fixes #322

Before these changes every time the datasource assets where changed the group membership was refreshed and forced the album view to be refreshed too.

This PR implements a new specific group observer that is only triggered when the groups are modified somehow.

To test:
 - Open the demo app
 - Tap on +
 - See if the album view show properly
 - Select an album
 - See if album shows properly
 - Go up to the collection view
 - Switch to the Photos App
 - Make some changes on the album ( add new album, delete one, change names)
 - Switch back to the demo
 - See if all the changes show properly.

