### PR TITLE
Add accessibility identifiers for use in UI tests

### DIFF
--- a/Pod/Classes/WPMediaGroupPickerViewController.m
+++ b/Pod/Classes/WPMediaGroupPickerViewController.m
@@ -40,6 +40,7 @@ static CGFloat const WPMediaGroupCellHeight = 86.0f;
     }
     [self.tableView registerClass:[WPMediaGroupTableViewCell class] forCellReuseIdentifier:NSStringFromClass([WPMediaGroupTableViewCell class])];
     self.tableView.rowHeight = WPMediaGroupCellHeight;
+    self.tableView.accessibilityIdentifier = @"AlbumTable";
 
     //Setup navigation
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelPicker:)];

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -320,6 +320,8 @@ static CGFloat SelectAnimationTime = 0.2;
     self.collectionView.bounces = YES;
     self.collectionView.alwaysBounceHorizontal = !self.options.scrollVertically;
     self.collectionView.alwaysBounceVertical = self.options.scrollVertically;
+
+    self.collectionView.accessibilityIdentifier = @"MediaCollection";
     
     // Register cell classes
     [self.collectionView registerClass:[WPMediaCollectionViewCell class]
@@ -419,6 +421,7 @@ static CGFloat SelectAnimationTime = 0.2;
     _previewActionButton = [UIButton buttonWithType:(UIButtonTypeSystem)];
     [_previewActionButton addTarget:self action:@selector(onPreviewButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [_previewActionButton setTitle:self.previewActionTitle forState:UIControlStateNormal];
+    _previewActionButton.accessibilityIdentifier = @"PreviewButton";
 
     return _previewActionButton;
 }
@@ -434,6 +437,7 @@ static CGFloat SelectAnimationTime = 0.2;
     _selectedActionButton.titleLabel.font = [UIFont boldSystemFontOfSize:font.pointSize];
     [_selectedActionButton addTarget:self action:@selector(onAddButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [_selectedActionButton setTitle:self.selectionActionTitle forState:UIControlStateNormal];
+    _selectedActionButton.accessibilityIdentifier = @"SelectedActionButton";
 
     return _selectedActionButton;
 }

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -321,6 +321,7 @@ static NSString *const ArrowDown = @"\u25be";
                                                             style:UIBarButtonItemStyleDone
                                                            target:self
                                                            action:@selector(finishPicker:)];
+    rightButtonItem.accessibilityIdentifier = @"SelectedActionButton";
     self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = rightButtonItem;
 }
 


### PR DESCRIPTION
This PR adds accessibility identifiers to the media picker, for use in UI tests.

To test:

* Run the Example app.
* Use the accessibility inspector to confirm that the identifiers appear on the expected elements.

See also this WordPress iOS PR for their use in UI tests: https://github.com/wordpress-mobile/WordPress-iOS/pull/11315