### PR TITLE
Bump pod version to 1.4.1-beta.1

### DIFF
--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.4.0"
+  s.version          = "1.4.1-beta.1"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
This bumps the pod version to 1.4.1-beta.1 for a beta release of the pod. (I meant to do this as part of https://github.com/wordpress-mobile/MediaPicker-iOS/pull/325.)