### PR TITLE
Allow preferredStatusBarStyle to be set in WPMediaPickerOptions

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.4.0)
+  - WPMediaPicker (1.4.1-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: fdb0ce41d7eb002132a6844b2dad26290b84ce78
+  WPMediaPicker: c6873fefaee96c4cae808a3e9401f50ee694075e
 
 PODFILE CHECKSUM: 7c47e10b39aca62b1f30c3c4260cc99456cf95f8
 

--- a/Pod/Classes/WPMediaPickerOptions.h
+++ b/Pod/Classes/WPMediaPickerOptions.h
@@ -48,4 +48,9 @@
  */
 @property (nonatomic, strong, nonnull) NSSet<NSString *> *badgedUTTypes;
 
+/**
+ The status bar style to use for the media picker.
+ */
+@property (nonatomic, assign) UIStatusBarStyle preferredStatusBarStyle;
+
 @end

--- a/Pod/Classes/WPMediaPickerOptions.m
+++ b/Pod/Classes/WPMediaPickerOptions.m
@@ -16,6 +16,7 @@
         _showSearchBar = NO;
         _showActionBar = YES;
         _badgedUTTypes = [NSSet set];
+        _preferredStatusBarStyle = UIStatusBarStyleDefault;
     }
     return self;
 }
@@ -31,6 +32,7 @@
     options.showSearchBar = self.showSearchBar;
     options.showActionBar = self.showActionBar;
     options.badgedUTTypes = [self.badgedUTTypes copy];
+    options.preferredStatusBarStyle = self.preferredStatusBarStyle;
 
     return options;
 }

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -391,6 +391,10 @@ static CGFloat SelectAnimationTime = 0.2;
      ];
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return self.options.preferredStatusBarStyle;
+}
+
 #pragma mark - Action bar
 
 - (UIView *)actionBar

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -73,9 +73,13 @@ static NSString *const ArrowDown = @"\u25be";
     // Dispose of any resources that can be recreated.
 }
 
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [self.mediaPicker preferredStatusBarStyle];
+}
+
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
-    return self.internalNavigationController.topViewController;
+    return nil;
 }
 
 - (UIViewController *)childViewControllerForHomeIndicatorAutoHidden


### PR DESCRIPTION
Currently in WPiOS, we have a category on `WPNavigationMediaPickerViewController` which overrides `preferredStatusBarStyle`. Overriding methods in categories can cause undefined behavior and is not guaranteed to work as we expect. While working on https://github.com/wordpress-mobile/WordPress-iOS/pull/11559, I have started to see Xcode warning about this:

![image](https://user-images.githubusercontent.com/1773641/57458883-0ce5d700-726a-11e9-8be7-58c41c0479d6.png)

My solution here is to add an extra property, `preferredStatusBarStyle` to `WPMediaPickerOptions` so that it can be configured without incurring undefined behavior. This means WPiOS can use this property rather than overriding with a category.

To test:

- The example ap still works as expected.

