### PR TITLE
Fix selection frame update on rotation.

### DIFF
--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -67,6 +67,7 @@ static const CGFloat LabelRegularFontSize = 13;
 - (void)layoutSubviews {
     [super layoutSubviews];
     self.gradientView.layer.sublayers.firstObject.frame = self.gradientView.bounds;
+    self.selectionFrame.frame = self.backgroundView.frame;
 }
 
 - (void)commonInit


### PR DESCRIPTION
This PR fixes an error where the selection frame on media selected was not updated when rotating the device.

To test:
 - Start de demo app
 - Tap on the +
 - Select Camera Roll
 - Select some of the images.
 - Rotate the device
 - Check that the selection is update to the correct cell size.

