### PR TITLE
Fix preview frame media sizes

### DIFF
--- a/Pod/Classes/WPAssetViewController.m
+++ b/Pod/Classes/WPAssetViewController.m
@@ -36,15 +36,15 @@
     self.imageView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.imageView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = YES;
     [self.imageView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
-    [self.imageView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.topAnchor].active = YES;
-    [self.imageView.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.bottomAnchor].active = YES;
+    [self.imageView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor].active = YES;
+    [self.imageView.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.topAnchor].active = YES;
 
     [self.view addSubview:self.videoView];
     self.videoView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.videoView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = YES;
     [self.videoView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
-    [self.videoView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.topAnchor].active = YES;
-    [self.videoView.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.bottomAnchor].active = YES;
+    [self.videoView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.bottomAnchor].active = YES;
+    [self.videoView.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.topAnchor].active = YES;
     self.videoView.delegate = self;
 
     [self.view addSubview:self.activityIndicatorView];

--- a/Pod/Classes/WPAssetViewController.m
+++ b/Pod/Classes/WPAssetViewController.m
@@ -36,15 +36,15 @@
     self.imageView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.imageView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = YES;
     [self.imageView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
-    [self.imageView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.topAnchor].active = YES;
-    [self.imageView.heightAnchor constraintEqualToAnchor:self.view.heightAnchor].active = YES;
+    [self.imageView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
+    [self.imageView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
 
     [self.view addSubview:self.videoView];
     self.videoView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.videoView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = YES;
     [self.videoView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
-    [self.videoView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.topAnchor].active = YES;
-    [self.videoView.heightAnchor constraintEqualToAnchor:self.view.heightAnchor].active = YES;
+    [self.videoView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
+    [self.videoView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
     self.videoView.delegate = self;
 
     [self.view addSubview:self.activityIndicatorView];

--- a/Pod/Classes/WPAssetViewController.m
+++ b/Pod/Classes/WPAssetViewController.m
@@ -36,15 +36,15 @@
     self.imageView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.imageView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = YES;
     [self.imageView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
-    [self.imageView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-    [self.imageView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+    [self.imageView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.topAnchor].active = YES;
+    [self.imageView.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.bottomAnchor].active = YES;
 
     [self.view addSubview:self.videoView];
     self.videoView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.videoView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = YES;
     [self.videoView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
-    [self.videoView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = YES;
-    [self.videoView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
+    [self.videoView.topAnchor constraintEqualToAnchor:self.topLayoutGuide.topAnchor].active = YES;
+    [self.videoView.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.bottomAnchor].active = YES;
     self.videoView.delegate = self;
 
     [self.view addSubview:self.activityIndicatorView];


### PR DESCRIPTION
The asset preview was not being correctly centered on phones with no home button.

This PR updates the screen to take in account the top and bottom guidelines.

To test:
 - Start the demo app
 - Tap on +
 - Open the camera roll
 - LongPress or ForceTouch an asset to see it's preview
 - Check that image/video is centered.
 - Rotate the device and check that media is still centered.

