### PR TITLE
Make sure orientation is correctly set when saving images to the camera roll

### DIFF
--- a/Pod/Classes/WPImageExporter.m
+++ b/Pod/Classes/WPImageExporter.m
@@ -3,7 +3,6 @@
 @import MobileCoreServices;
 @import ImageIO;
 
-
 @implementation WPImageExporter
 
 + (NSURL *)temporaryFileURLWithExtension:(NSString *)fileExtension
@@ -16,18 +15,50 @@
 
 + (BOOL)writeImage:(UIImage *)image withMetadata:(NSDictionary *)metadata toURL:(NSURL *)fileURL;
 {
-    NSMutableDictionary *properties = [[NSMutableDictionary alloc] initWithDictionary:@{ (NSString *)kCGImageDestinationLossyCompressionQuality: @(0.9)}];
+    NSMutableDictionary *properties = [[NSMutableDictionary alloc] initWithDictionary:@{ (NSString *)kCGImageDestinationLossyCompressionQuality: @(0.9) }];
+
+    NSMutableDictionary *adjustedMetadata = [[NSMutableDictionary alloc] initWithDictionary:metadata];
+    NSNumber *adjustedOrientation = @([self CGImagePropertyOrientationForUIImageOrientation: image.imageOrientation]);
+    adjustedMetadata[(NSString *)kCGImagePropertyOrientation] = adjustedOrientation;
+
+    if (adjustedMetadata[(NSString *)kCGImagePropertyTIFFDictionary] != nil) {
+        NSMutableDictionary *adjustedTIFF = [[NSMutableDictionary alloc] initWithDictionary:adjustedMetadata[(NSString *)kCGImagePropertyTIFFDictionary]];
+        adjustedTIFF[(NSString *)kCGImagePropertyTIFFOrientation] = adjustedOrientation;
+        adjustedMetadata[(NSString *)kCGImagePropertyTIFFDictionary] = adjustedTIFF;
+    }
+
+    if (adjustedMetadata[(NSString *)kCGImagePropertyIPTCDictionary] != nil) {
+        NSMutableDictionary *adjustedIPTC = [[NSMutableDictionary alloc] initWithDictionary:adjustedMetadata[(NSString *)kCGImagePropertyIPTCDictionary]];
+        adjustedIPTC[(NSString *)kCGImagePropertyIPTCImageOrientation] = adjustedOrientation;
+        adjustedMetadata[(NSString *)kCGImagePropertyIPTCDictionary] = adjustedIPTC;
+    }
+
     CGImageDestinationRef destination = CGImageDestinationCreateWithURL((CFURLRef)fileURL, kUTTypeJPEG, 1, nil);
     if (destination == NULL) {
         return NO;
     }
     CGImageRef imageRef = image.CGImage;
+
     CGImageDestinationSetProperties(destination, (CFDictionaryRef)properties);
-    CGImageDestinationAddImage(destination, imageRef, (CFDictionaryRef)metadata);
+    CGImageDestinationAddImage(destination, imageRef, (CFDictionaryRef)adjustedMetadata);
+
     BOOL result = CGImageDestinationFinalize(destination);
 
     CFRelease(destination);
     return result;
+}
+
++ (CGImagePropertyOrientation) CGImagePropertyOrientationForUIImageOrientation:(UIImageOrientation) uiOrientation {
+    switch (uiOrientation) {
+        case UIImageOrientationUp: return kCGImagePropertyOrientationUp;
+        case UIImageOrientationDown: return kCGImagePropertyOrientationDown;
+        case UIImageOrientationLeft: return kCGImagePropertyOrientationLeft;
+        case UIImageOrientationRight: return kCGImagePropertyOrientationRight;
+        case UIImageOrientationUpMirrored: return kCGImagePropertyOrientationUpMirrored;
+        case UIImageOrientationDownMirrored: return kCGImagePropertyOrientationDownMirrored;
+        case UIImageOrientationLeftMirrored: return kCGImagePropertyOrientationLeftMirrored;
+        case UIImageOrientationRightMirrored: return kCGImagePropertyOrientationRightMirrored;
+    }
 }
 
 @end


### PR DESCRIPTION
Fixes #337 

This PR makes sure that images added to the camera roll have the correct orientation set

To test:
1. Start the demo app
2. Tap on the + button
3. Select one of the albums
4. Tap on the camera capture preview
5. Rotate the device upside down
6. Capture an photo
7. Confirm
8. See the image being added to the camera roll with the correct orientation
