### PR TITLE
Media Picker action bar: Allow customizing background color.

### DIFF
--- a/Pod/Classes/WPActionBar.h
+++ b/Pod/Classes/WPActionBar.h
@@ -8,6 +8,11 @@
 @property (nonatomic, strong) UIColor *lineColor UI_APPEARANCE_SELECTOR;
 
 /**
+The color for the action bar background.
+*/
+@property (nonatomic, strong) UIColor *barBackgroundColor UI_APPEARANCE_SELECTOR;
+
+/**
  Adds the given button to the left side of the bar
 
  @param button The button to add.

--- a/Pod/Classes/WPActionBar.m
+++ b/Pod/Classes/WPActionBar.m
@@ -83,6 +83,16 @@ static const UIEdgeInsets ButtonsBarEdgeInsets = {0, 20, 0, 20}; //top, left, bo
 
 #pragma mark - public methods
 
+- (UIColor *)barBackgroundColor
+{
+    return self.backgroundColor;
+}
+
+- (void)setBarBackgroundColor:(UIColor *)barBackgroundColor
+{
+    self.backgroundColor = barBackgroundColor;
+}
+
 - (UIColor *)lineColor
 {
     return self.lineView.backgroundColor;

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.6.0"
+  s.version          = "1.6.1-beta.1"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/12759

This allows the customization of the `WPActionBar` background color.

To test:
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13635

