### PR TITLE
Check NSNotFound before adjusting indexes

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.6.1-beta.1)
+  - WPMediaPicker (1.6.2-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 370b1c1597afc0dd3664c361748fdfd13530d4c6
+  WPMediaPicker: 1fff9109d71dd765931d87ace75cecbaab42475d
 
 PODFILE CHECKSUM: 6b0e391139d3864c72fde997a1418dbfe9bf5126
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -362,7 +362,9 @@
 {
     NSMutableIndexSet *adjustedSet = [NSMutableIndexSet new];
     [indexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
-        [adjustedSet addIndex:[self adjustedIndexForIndex:idx forCount: count]];
+        if (idx != NSNotFound) {
+            [adjustedSet addIndex:[self adjustedIndexForIndex:idx forCount: count]];
+        }
     }];
 
     // Returns a non-mutable copy.

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.6.1"
+  s.version          = "1.6.2-beta.1"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/MediaPicker-iOS/issues/349

### To test

I wasn't able to reproduce the original issue. Just check if the Media Picker behaves correctly.

