### PR TITLE
Make sure we don't interfere on show after VC navigation bars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 `WPMediaPicker` adheres to [Semantic Versioning](http://semver.org/).
 
 #### Releases
+- `1.7.0` Release  - [1.7](#1.7.0)
 - `1.6.0` Release  - [1.6](#1.6.0)
 - `1.5.0` Release  - [1.5](#1.5.0)
 - `1.4.2` Release  - [1.4.2](#1.4.2)
@@ -28,11 +29,18 @@ All notable changes to this project will be documented in this file.
 - `0.15` Releases - [0.15](#15)
 
 ---
-## [1.6.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.6.0)
-Released on 2019-10-18. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.6.0).
+## [1.7.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.7.0)
+Released on 2019-10-18. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.7.0).
 
 ### Changes
 - Fix image/photo capture when it's done with the device rotated. #337 #338
+
+---
+## [1.6.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.6.0)
+Released on 2019-10-18. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.6.0).
+
+### Fixed
+- Fix bug where VC present after selection was being changed by selection updates. #353
 
 ---
 ## [1.5.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.5.0)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.7.0-beta.1)
+  - WPMediaPicker (1.7.0-beta.2)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 98f82127a0e2715664097a339e2c764906432709
+  WPMediaPicker: d4f6fb1f2f803469c28ada02e2cc60e4e5140882
 
 PODFILE CHECKSUM: 6b0e391139d3864c72fde997a1418dbfe9bf5126
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -13,6 +13,7 @@ UIPopoverPresentationControllerDelegate
 @property (nonatomic, strong) WPMediaPickerViewController *mediaPicker;
 @property (nonatomic, strong) WPMediaGroupPickerViewController *groupViewController;
 @property (nonatomic, strong) NSObject *changesObserver;
+@property (nonatomic, weak) UIViewController *afterSelectionViewController;
 @end
 
 @implementation WPNavigationMediaPickerViewController
@@ -359,6 +360,9 @@ static NSString *const ArrowDown = @"\u25be";
 }
 
 - (void)updateSelectionAction {
+    if (self.internalNavigationController.topViewController == self.afterSelectionViewController) {
+        return;
+    }
     if (self.mediaPicker.options.showActionBar || self.mediaPicker.selectedAssets.count == 0 || !self.mediaPicker.options.allowMultipleSelection) {
         self.internalNavigationController.topViewController.navigationItem.rightBarButtonItem = nil;
         return;
@@ -382,6 +386,7 @@ static NSString *const ArrowDown = @"\u25be";
 - (void)showAfterViewController:(UIViewController *)viewController
 {
     NSParameterAssert(viewController);
+    self.afterSelectionViewController = viewController;
     [self.internalNavigationController pushViewController:viewController animated:YES];
 }
 

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.7.0-beta.1"
+  s.version          = "1.7.0-beta.2"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/9685

To test:
 - Start the demo app
 - Select the Options on Top
 - Activate the Show Post Processing Step
 - Press Done
 - Press on + on the Top Right
 - Select an asset
 - Check that the empty post-processing step shows and navigation bar is ok.

 - Test the bug above using this PR: 

