### PR TITLE
Fix a crash in WCiOS by using weak self in `WPMediaPickerViewController`'s collection view `performBatchUpdates` completion block

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.7.0-beta.2)
+  - WPMediaPicker (1.7.1-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: d4f6fb1f2f803469c28ada02e2cc60e4e5140882
+  WPMediaPicker: 1b770d4d4f14fbfb7c421c53c761a521fc23bf12
 
 PODFILE CHECKSUM: 6b0e391139d3864c72fde997a1418dbfe9bf5126
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -664,6 +664,7 @@ static CGFloat SelectAnimationTime = 0.2;
     if ([removed containsIndex:self.assetIndexInPreview.item]){
         self.assetIndexInPreview = nil;
     }
+    __weak __typeof__(self) weakSelf = self;
     [self.collectionView performBatchUpdates:^{
         if (removed) {
             [self.collectionView deleteItemsAtIndexPaths:[self indexPathsFromIndexSet:removed section:0]];
@@ -684,8 +685,8 @@ static CGFloat SelectAnimationTime = 0.2;
             }
         }
     } completion:^(BOOL finished) {
-        [self refreshSelection];
-        [self.collectionView reloadItemsAtIndexPaths:self.collectionView.indexPathsForSelectedItems];        
+        [weakSelf refreshSelection];
+        [weakSelf.collectionView reloadItemsAtIndexPaths:weakSelf.collectionView.indexPathsForSelectedItems];
     }];
 
 }

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.7.0"
+  s.version          = "1.7.1-beta.1"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/issues/2581

## Changes

- Updated `WPMediaPickerViewController` to use weak self in the batch updates `performBatchUpdates` completion block
- Bumped pod version and ran `pod install` on the sample project

## To test

In WCiOS [`develop`](https://github.com/woocommerce/woocommerce-ios/tree/6c0960c191a541bf22825ecb36d98badb70afefe), we were able to reproduce a crash after leaving the WP media picker screen when the second page of images just came in following the steps below ([Sentry issue](https://sentry.io/organizations/a8c/issues/1723508991/?project=1458804&query=is%3Aunresolved&statsPeriod=14d)):

- Go to the Products tab
- Tap on a simple product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Tap "WordPress Media Library" from the action sheet, and make sure to do the following step quickly!
- After the first page of photos is loaded and **before or right when the second page comes in**, quickly select an image and tap "Add 1" in the navigation bar --> the app crashes shortly
