### PR TITLE
Allow MediaPickerViewControllerDelegate errors to be nullable

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -218,7 +218,7 @@
  *  @param error The error to show
  *  @return YES if the error was handled by the delegate
  */
-- (BOOL)mediaPickerController:(nonnull WPMediaPickerViewController *)picker handleError:(nonnull NSError *)error;
+- (BOOL)mediaPickerController:(nonnull WPMediaPickerViewController *)picker handleError:(nullable NSError *)error;
 
 @end
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -351,7 +351,7 @@ static NSString *const ArrowDown = @"\u25be";
     [self updateSelectionAction];
 }
 
-- (BOOL)mediaPickerController:(nonnull WPMediaPickerViewController *)picker handleError:(nonnull NSError *)error {
+- (BOOL)mediaPickerController:(nonnull WPMediaPickerViewController *)picker handleError:(nullable NSError *)error {
     if ([self.delegate respondsToSelector:@selector(mediaPickerController:handleError:)]) {
         return [self.delegate mediaPickerController:picker handleError:error];        
     } else {

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.7.1"
+  s.version          = "1.7.2-beta.1"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
This PR allows the error parameter passed to `MediaPickerViewControllerDelegate.mediaPickerController(_:handleError:)` to be null. This seems to be one of the causes of https://github.com/wordpress-mobile/WordPress-iOS/issues/14958 in my investigation, where we call a failure block (due to no assets being present), but also have no error to pass.

**To test**

- Build and and run the [associated WPiOS branch](https://github.com/wordpress-mobile/WordPress-iOS/pull/14989) on iOS 14
- Visit the Media Library, choose +, tap Choose From My Device, then Select More Photos (or Select Photos if this is the first time you've run the app). Ensure that no photos are selected and tap Done.
- The media picker should be displayed with no content, and the app should not crash.