### PR TITLE
[iOS 14] Handle nil assetCollection and prevent crash

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.7.1-beta.1)
+  - WPMediaPicker (1.7.2-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 1b770d4d4f14fbfb7c421c53c761a521fc23bf12
+  WPMediaPicker: ce9b4d729c5aaa8158574faf065e1cf81594822c
 
 PODFILE CHECKSUM: 6b0e391139d3864c72fde997a1418dbfe9bf5126
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.7.2-beta.1)
+  - WPMediaPicker (1.7.2)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: ce9b4d729c5aaa8158574faf065e1cf81594822c
+  WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
 
 PODFILE CHECKSUM: 6b0e391139d3864c72fde997a1418dbfe9bf5126
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -229,7 +229,7 @@
                                                                                            dispatchQueue: self.imageGenerationQueue]];
     }
     self.cachedCollections = newCachedAssetCollection;
-    if (self.assetsCollections.count > 0){
+    if (self.assetsCollections != nil){
         if (!self.activeAssetsCollection || [self.assetsCollections indexOfObject:self.activeAssetsCollection] == NSNotFound) {
             self.activeAssetsCollection = [self.assetsCollections firstObject];
         }

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.7.2-beta.1"
+  s.version          = "1.7.2"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WPMediaPicker"
-  s.version          = "1.7.1"
+  s.version          = "1.7.2-beta.1"
   s.summary          = "WPMediaPicker is an iOS controller that allows capture and picking of media assets."
   s.description      = <<-DESC
                        WPMediaPicker is an iOS controller that allows capture and picking of media assets.


### PR DESCRIPTION
This PR is an alternative to #360, to fix https://github.com/wordpress-mobile/WordPress-iOS/issues/14958. This fixes the issue by checking for a nil asset collection.

**To test**

- Build and and run the associated WPiOS branch on iOS 14
- Visit the Media Library, choose +, tap Choose From My Device, then Select More Photos (or Select Photos if this is the first time you've run the app). Ensure that no photos are selected and tap Done.
- The media picker should be displayed with no content, and the app should not crash.
