### PR TITLE
371 Check conformance on call to optional method

### DIFF
--- a/Pod/Classes/WPMediaCollectionViewCell.m
+++ b/Pod/Classes/WPMediaCollectionViewCell.m
@@ -210,7 +210,11 @@ static const CGFloat LabelRegularFontSize = 13;
             accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Audio, %@", @"Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio."), formattedDate];
             break;
         case WPMediaTypeOther:
-            accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Document: %@", @"Accessibility label for other media items in the media collection view. The parameter is the filename file."), [_asset filename]];
+            if([_asset respondsToSelector:@selector(filename)]) {
+                accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Document: %@", @"Accessibility label for other media items in the media collection view. The parameter is the filename file."), [_asset filename]];
+            } else {
+                accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Document, %@", @"Accessibility label for other media items in the media collection view. The parameter is the creation date of the document."), formattedDate];
+            }
             break;
         default:
             break;

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.7.2'
+  s.version       = '1.7.3-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes #371 

## Description
A rare crash found in WooCommerce iOS was caused by access to the `filename` of an asset, which is an optional member of the `WPMediaAsset` protocol. In WCiOS, this was not implemented, so the app crashed with `NSInvalidArgumentException -[WooCommerce.CancellableMedia filename]: unrecognized selector sent to instance`

To prevent this, we check for `respondsToSelector:` before getting the filename, and default to using the creation date in the accessibility labels for documents when filename is not implemented.

The fallback to creation date matches the existing approach taken for other media types.

## To test
Reproducing the crash in WCiOS is challenging, as it's in a path which _shouldn't_ be followed by WCiOS, because the API request for media items is filtered to images only, and this crash occurs when there are assets shown which are of type `WPMediaTypeOther`.

Some small code changes in the WooCommerce app make it much easier to reproduce. 
1. To see the crashing behaviour, use this branch: [`hack/example-media-picker-crash`](https://github.com/woocommerce/woocommerce-ios/tree/hack/example-media-picker-crash)
2. Connect to a site with a non-audio/video/image document in the media library.
3. Open a media picker, e.g. Products > Add > Add Product Image
4. If the document is in the first page of results, the app will crash, otherwise scroll until it shows to see the crash.

To test with the fix
1. Check out this branch of the media picker, and update the WCiOS Podfile to include `pod 'WPMediaPicker', :path => "path/to/MediaPicker-iOS"`
2. Run `bundle exec rake dependencies`
3. Follow steps above, app will not crash.
4. Check VoiceOver for the document, it will be announced as "Document: creation date" (using the fallback because filename is not implemented)

Crash | Fix
------|------
![Crash](https://user-images.githubusercontent.com/2472348/134386182-b5b08e5c-348d-44b9-96c8-cf7f13e2a123.mp4) | ![Fixed](https://user-images.githubusercontent.com/2472348/134386141-ce4a0e89-b824-4ee5-be14-f3efcee9f141.mp4)

