### PR TITLE
PHPhotoLibrary: Register change observer after asking for permission

### DIFF
--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -47,7 +47,6 @@
     _refreshGroups = YES;
     _cachedCollections = [[NSMutableArray alloc] init];
     _imageGenerationQueue = dispatch_queue_create("org.wordpress.wpmediapicker.WPPHAssetDataSource", DISPATCH_QUEUE_SERIAL);
-    [[PHPhotoLibrary sharedPhotoLibrary] registerChangeObserver:self];
     return self;
 }
 
@@ -131,6 +130,13 @@
                     failure:(WPMediaFailureBlock)failureBlock
 {
     [self checkPermissionStatus:^(PHAuthorizationStatus status) {
+
+        /// Starting from iOS 15.2 we should do the registration
+        /// after asking user for permission
+        /// Solution proposed here - https://developer.apple.com/forums/thread/696804
+        ///
+        [[PHPhotoLibrary sharedPhotoLibrary] registerChangeObserver:self];
+
         switch (status) {
             case PHAuthorizationStatusRestricted:
             {


### PR DESCRIPTION
Fixes #375 

### Description
As proposed in https://developer.apple.com/forums/thread/696804 this PR register's `PHPhotoLibrary` change observer after asking for permission from the user.

### Steps to test
- Using Xcode 13.2.1 - Run the example app in a device/simulator running iOS 15.2 and make sure that you can access photos without any issues.
- Also, make sure that the changes done to the photos library reflect in the app. (To ensure that the observer is working as expected)

Note: I have only tested the above points in a simulator and it would be great if you can test this in a device.

