### PR TITLE
Add support for custom header views

### DIFF
--- a/Example/WPMediaPicker.xcodeproj/project.pbxproj
+++ b/Example/WPMediaPicker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		173B215327873F2E00D4DD6B /* SampleCustomHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 173B215227873F2E00D4DD6B /* SampleCustomHeaderView.m */; };
 		17475FB81FB46DED00252689 /* SampleCellOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 17475FB71FB46DED00252689 /* SampleCellOverlayView.m */; };
 		17F64FE01E6DDC74006C5A2B /* CustomPreviewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
@@ -42,6 +43,8 @@
 
 /* Begin PBXFileReference section */
 		1120051BDDDC8A558883872E /* Pods-WPMediaPicker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WPMediaPicker.release.xcconfig"; path = "Pods/Target Support Files/Pods-WPMediaPicker/Pods-WPMediaPicker.release.xcconfig"; sourceTree = "<group>"; };
+		173B215127873F2E00D4DD6B /* SampleCustomHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SampleCustomHeaderView.h; sourceTree = "<group>"; };
+		173B215227873F2E00D4DD6B /* SampleCustomHeaderView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SampleCustomHeaderView.m; sourceTree = "<group>"; };
 		17475FB61FB46DED00252689 /* SampleCellOverlayView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SampleCellOverlayView.h; sourceTree = "<group>"; };
 		17475FB71FB46DED00252689 /* SampleCellOverlayView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SampleCellOverlayView.m; sourceTree = "<group>"; };
 		17F64FDE1E6DDC74006C5A2B /* CustomPreviewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomPreviewViewController.h; sourceTree = "<group>"; };
@@ -155,6 +158,8 @@
 				17F64FDF1E6DDC74006C5A2B /* CustomPreviewViewController.m */,
 				17475FB61FB46DED00252689 /* SampleCellOverlayView.h */,
 				17475FB71FB46DED00252689 /* SampleCellOverlayView.m */,
+				173B215127873F2E00D4DD6B /* SampleCustomHeaderView.h */,
+				173B215227873F2E00D4DD6B /* SampleCustomHeaderView.m */,
 				6003F59C195388D20070C39A /* AppDelegate.h */,
 				6003F59D195388D20070C39A /* AppDelegate.m */,
 				6003F5A8195388D20070C39A /* Images.xcassets */,
@@ -387,6 +392,7 @@
 				B5FF3BEA1CAD8AB100C1D597 /* PostProcessingViewController.m in Sources */,
 				6003F59E195388D20070C39A /* AppDelegate.m in Sources */,
 				17475FB81FB46DED00252689 /* SampleCellOverlayView.m in Sources */,
+				173B215327873F2E00D4DD6B /* SampleCustomHeaderView.m in Sources */,
 				FF355D9E1FB5EB4A00244E6D /* WPPHAssetDataSource+Search.m in Sources */,
 				FFFFD8811A447E67000FC184 /* DemoViewController.m in Sources */,
 				6003F59A195388D20070C39A /* main.m in Sources */,

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -4,7 +4,9 @@
 #import "OptionsViewController.h"
 #import "PostProcessingViewController.h"
 #import "SampleCellOverlayView.h"
+#import "SampleCustomHeaderView.h"
 #import <WPMediaPicker/WPMediaPicker.h>
+
 @import MobileCoreServices;
 
 static CGFloat const CellHeight = 100.0f;
@@ -51,7 +53,8 @@ static CGFloat const CellHeight = 100.0f;
                      MediaPickerOptionsCustomPreview:@(NO),
                      MediaPickerOptionsScrollInputPickerVertically:@(YES),
                      MediaPickerOptionsShowSampleCellOverlays:@(NO),
-                     MediaPickerOptionsShowSearchBar:@(YES)
+                     MediaPickerOptionsShowSearchBar:@(YES),
+                     MediaPickerOptionsShowCustomHeader:@(NO)
                      };
 
 }

--- a/Example/WPMediaPicker/DemoViewController.m
+++ b/Example/WPMediaPicker/DemoViewController.m
@@ -255,6 +255,25 @@ static CGFloat const CellHeight = 100.0f;
     return error.domain != WPMediaPickerErrorDomain;    
 }
 
+- (void)mediaPickerController:(WPMediaPickerViewController *)picker configureCustomHeaderView:(UICollectionReusableView *)headerView {
+    if (![headerView isKindOfClass:[SampleCustomHeaderView class]]) {
+        return;
+    }
+
+    SampleCustomHeaderView *view = (SampleCustomHeaderView *)headerView;
+    view.backgroundColor = [UIColor greenColor];
+}
+
+- (BOOL)mediaPickerControllerShouldShowCustomHeaderView:(WPMediaPickerViewController *)picker
+{
+    return [self.options[MediaPickerOptionsShowCustomHeader] boolValue] == YES;
+}
+
+- (CGSize)mediaPickerControllerReferenceSizeForCustomHeaderView:(WPMediaPickerViewController *)picker
+{
+    return CGSizeMake(300, 200);
+}
+
 #pragma - Actions
 
 - (void) clearSelection:(id) sender
@@ -295,6 +314,10 @@ static CGFloat const CellHeight = 100.0f;
 
     if ([self.options[MediaPickerOptionsShowSampleCellOverlays] boolValue]) {
         [self.mediaPicker.mediaPicker registerClassForReusableCellOverlayViews:[SampleCellOverlayView class]];
+    }
+
+    if ([self.options[MediaPickerOptionsShowCustomHeader] boolValue]) {
+        [self.mediaPicker.mediaPicker registerClassForCustomHeaderView:[SampleCustomHeaderView class]];
     }
     
     [self presentViewController:self.mediaPicker animated:YES completion:nil];

--- a/Example/WPMediaPicker/OptionsViewController.h
+++ b/Example/WPMediaPicker/OptionsViewController.h
@@ -11,6 +11,9 @@ extern NSString const *MediaPickerOptionsScrollInputPickerVertically;
 extern NSString const *MediaPickerOptionsShowSampleCellOverlays;
 extern NSString const *MediaPickerOptionsShowSearchBar;
 extern NSString const *MediaPickerOptionsShowActionBar;
+/// Note that a custom header cannot be displayed at the same time as the in-picker camera capture cell.
+/// If both are specified, the custom header will take precedence.
+extern NSString const *MediaPickerOptionsShowCustomHeader;
 
 @class OptionsViewController;
 

--- a/Example/WPMediaPicker/OptionsViewController.m
+++ b/Example/WPMediaPicker/OptionsViewController.m
@@ -13,6 +13,7 @@ NSString const *MediaPickerOptionsScrollInputPickerVertically = @"MediaPickerOpt
 NSString const *MediaPickerOptionsShowSampleCellOverlays = @"MediaPickerOptionsShowSampleCellOverlays";
 NSString const *MediaPickerOptionsShowSearchBar = @"MediaPickerOptionsShowSearchBar";
 NSString const *MediaPickerOptionsShowActionBar = @"MediaPickerOptionsShowActionBar";
+NSString const *MediaPickerOptionsShowCustomHeader = @"MediaPickerOptionsShowCustomHeader";
 
 
 typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
@@ -27,6 +28,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     OptionsViewControllerCellShowSampleCellOverlays,
     OptionsViewControllerCellShowSearchBar,
     OptionsViewControllerCellShowActionBar,
+    OptionsViewControllerCellShowCustomHeader,
     OptionsViewControllerCellTotal
 };
 
@@ -43,6 +45,7 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
 @property (nonatomic, strong) UITableViewCell *cellOverlaysCell;
 @property (nonatomic, strong) UITableViewCell *showSearchBarCell;
 @property (nonatomic, strong) UITableViewCell *showActionBarCell;
+@property (nonatomic, strong) UITableViewCell *showCustomHeaderCell;
 
 @end
 
@@ -119,6 +122,13 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
     self.showActionBarCell.accessoryView = [[UISwitch alloc] init];
     ((UISwitch *)self.showActionBarCell.accessoryView).on = [self.options[MediaPickerOptionsShowActionBar] boolValue];
     self.showActionBarCell.textLabel.text = NSLocalizedString(@"Show Action Bar", @"");
+
+    self.showCustomHeaderCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
+    self.showCustomHeaderCell.accessoryView = [[UISwitch alloc] init];
+    ((UISwitch *)self.showCustomHeaderCell.accessoryView).on = [self.options[MediaPickerOptionsShowCustomHeader] boolValue];
+    self.showCustomHeaderCell.textLabel.text = NSLocalizedString(@"Show Custom Header", @"");
+    self.showCustomHeaderCell.detailTextLabel.text = NSLocalizedString(@"If custom header and capture cell are enabled, custom header takes precedence.", @"");
+    self.showCustomHeaderCell.detailTextLabel.numberOfLines = 2;
 }
 
 #pragma mark - Table view data source
@@ -166,6 +176,8 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
             return self.showSearchBarCell;
         case OptionsViewControllerCellShowActionBar:
             return self.showActionBarCell;
+        case OptionsViewControllerCellShowCustomHeader:
+            return self.showCustomHeaderCell;
         default:
             break;
     }
@@ -195,7 +207,8 @@ typedef NS_ENUM(NSInteger, OptionsViewControllerCell){
              MediaPickerOptionsScrollInputPickerVertically:@(((UISwitch *)self.scrollInputPickerCell.accessoryView).on),
              MediaPickerOptionsShowSampleCellOverlays:@(((UISwitch *)self.cellOverlaysCell.accessoryView).on),
              MediaPickerOptionsShowSearchBar:@(((UISwitch *)self.showSearchBarCell.accessoryView).on),
-             MediaPickerOptionsShowActionBar:@(((UISwitch *)self.showActionBarCell.accessoryView).on)
+             MediaPickerOptionsShowActionBar:@(((UISwitch *)self.showActionBarCell.accessoryView).on),
+             MediaPickerOptionsShowCustomHeader:@(((UISwitch *)self.showCustomHeaderCell.accessoryView).on)
              };
         
         [delegate optionsViewController:self changed:newOptions];

--- a/Example/WPMediaPicker/SampleCustomHeaderView.h
+++ b/Example/WPMediaPicker/SampleCustomHeaderView.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SampleCustomHeaderView : UICollectionReusableView
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/WPMediaPicker/SampleCustomHeaderView.m
+++ b/Example/WPMediaPicker/SampleCustomHeaderView.m
@@ -1,0 +1,36 @@
+#import "SampleCustomHeaderView.h"
+
+@implementation SampleCustomHeaderView
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    if (self = [super initWithFrame:frame]) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    if (self = [super initWithCoder:aDecoder]) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit
+{
+    self.backgroundColor = [UIColor redColor];
+
+    UILabel *label = [UILabel new];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = NSLocalizedString(@"Custom Header", @"");
+    [self addSubview:label];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [label.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+        [label.centerYAnchor constraintEqualToAnchor:self.centerYAnchor]
+    ]];
+}
+
+@end

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -158,7 +158,7 @@
 /**
  *  Asks the delegate whether an overlay view should be shown for the cell for
  *  the specified media asset. If you return `YES` from this method, you must
- *  have registered a reuse class though `-[WPMediaPickerViewController registerClassForReusableCellOverlayViews:]`.
+ *  have registered a reuse class through `-[WPMediaPickerViewController registerClassForReusableCellOverlayViews:]`.
  *
  *  @param asset The asset to display an overlay view for.
  *  @return `YES` if an overlay view should be displayed, `NO`, if not.
@@ -177,6 +177,33 @@
  *  @param asset       The asset to configure the overlay for.
  */
 - (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker willShowOverlayView:(nonnull UIView *)overlayView forCellForAsset:(nonnull id<WPMediaAsset>)asset;
+
+/**
+ *  Asks the delegate to configure a custom header view. You must have registered a reuse class
+ *  through `-[WPMediaPickerViewController registerClassForCustomHeaderView:]` and returned `YES`
+ *  from `mediaPickerControllerShouldShowCustomHeaderView` otherwise this method will not be called.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @param headerView An instance of the custom header view type to configure.
+ */
+- (void)mediaPickerController:(nonnull WPMediaPickerViewController *)picker configureCustomHeaderView:(nonnull UICollectionReusableView *)headerView;
+
+/**
+ *  Asks the delegate whether a custom header view should be displayed.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @return `YES` if a custom header view should be shown, otherwise `NO`.
+ */
+- (BOOL)mediaPickerControllerShouldShowCustomHeaderView:(nonnull WPMediaPickerViewController *)picker;
+
+/**
+ *  Asks the delegate for a reference size for the registered custom header view, if one has been registered. This will only be called
+ *  if `mediaPickerControllerShouldShowCustomHeaderView` has been implemented and returns `YES`.
+ *
+ *  @param picker The controller object managing the assets picker interface.
+ *  @return A size for the header view to be displayed at.
+ */
+- (CGSize)mediaPickerControllerReferenceSizeForCustomHeaderView:(nonnull WPMediaPickerViewController *)picker;
 
 /**
  *  Gives the delegate an oportunity to react to a change in the number
@@ -340,6 +367,13 @@
  return `YES` from `mediaPickerController:shouldShowOverlayViewForCellForAsset:`
  */
 - (void)registerClassForReusableCellOverlayViews:(nonnull Class)overlayClass;
+
+/**
+ Register a `UICollectionReusableView` subclass to be displayed as an optional header at the top of the picker view.
+ For the header to be displayed, you must register a class using this method, and then
+ return a configured instance from `customHeaderViewForMediaPickerController:`
+ */
+- (void)registerClassForCustomHeaderView:(nonnull Class)overlayClass;
 
 /**
  Shows the search bar that was hidden by `hideSearchBar`. If the

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -18,6 +18,7 @@ static CGFloat const IPhone7LandscapeWidth = 667.0f;
 static CGFloat const IPadPortraitWidth = 768.0f;
 static CGFloat const IPadLandscapeWidth = 1024.0f;
 static CGFloat const IPadPro12LandscapeWidth = 1366.0f;
+static NSString *const CustomHeaderReuseIdentifier = @"CustomHeaderReuseIdentifier";
 
 @interface WPMediaPickerViewController ()
 <
@@ -181,6 +182,15 @@ static CGFloat SelectAnimationTime = 0.2;
     NSParameterAssert([overlayClass isSubclassOfClass:[UIView class]]);
 
     self.overlayViewClass = overlayClass;
+}
+
+- (void)registerClassForCustomHeaderView:(Class)overlayClass
+{
+    NSParameterAssert([overlayClass isSubclassOfClass:[UICollectionReusableView class]]);
+
+    [self.collectionView registerClass:overlayClass
+            forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                   withReuseIdentifier:CustomHeaderReuseIdentifier];
 }
 
 - (UICollectionViewFlowLayout *)layout
@@ -935,6 +945,12 @@ static CGFloat SelectAnimationTime = 0.2;
                   layout:(UICollectionViewLayout *)collectionViewLayout
 referenceSizeForHeaderInSection:(NSInteger)section
 {
+    if ([self shouldShowCustomHeaderView]) {
+        if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerControllerReferenceSizeForCustomHeaderView:)]) {
+            return [self.mediaPickerDelegate mediaPickerControllerReferenceSizeForCustomHeaderView:self];
+        }
+    }
+
     if ( [self isShowingCaptureCell] && self.options.showMostRecentFirst)
     {
         return self.cameraPreviewSize;
@@ -957,6 +973,15 @@ referenceSizeForFooterInSection:(NSInteger)section
            viewForSupplementaryElementOfKind:(NSString *)kind
                                  atIndexPath:(NSIndexPath *)indexPath
 {
+    // Custom header view support
+    if (kind == UICollectionElementKindSectionHeader && [self shouldShowCustomHeaderView]) {
+        if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerController:configureCustomHeaderView:)]) {
+            UICollectionReusableView *view = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:CustomHeaderReuseIdentifier forIndexPath:indexPath];
+            [self.mediaPickerDelegate mediaPickerController:self configureCustomHeaderView:view];
+            return view;
+        }
+    }
+
     if ((kind == UICollectionElementKindSectionHeader && self.options.showMostRecentFirst) ||
        (kind == UICollectionElementKindSectionFooter && !self.options.showMostRecentFirst))
     {
@@ -998,6 +1023,15 @@ referenceSizeForFooterInSection:(NSInteger)section
         WPMediaCollectionViewCell *mediaCell = (WPMediaCollectionViewCell *)cell;
         mediaCell.overlayView.hidden = YES;
     }
+}
+
+- (BOOL)shouldShowCustomHeaderView
+{
+    if ([self.mediaPickerDelegate respondsToSelector:@selector(mediaPickerControllerShouldShowCustomHeaderView:)]) {
+        return [self.mediaPickerDelegate mediaPickerControllerShouldShowCustomHeaderView:self];
+    }
+
+    return NO;
 }
 
 /**

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -318,6 +318,31 @@ static NSString *const ArrowDown = @"\u25be";
     }
 }
 
+- (BOOL)mediaPickerControllerShouldShowCustomHeaderView:(WPMediaPickerViewController *)picker
+{
+    if ([self.delegate respondsToSelector:@selector(mediaPickerControllerShouldShowCustomHeaderView:)]) {
+        return [self.delegate mediaPickerControllerShouldShowCustomHeaderView:picker];
+    }
+
+    return NO;
+}
+
+- (CGSize)mediaPickerControllerReferenceSizeForCustomHeaderView:(WPMediaPickerViewController *)picker
+{
+    if ([self.delegate respondsToSelector:@selector(mediaPickerControllerReferenceSizeForCustomHeaderView:)]) {
+        return [self.delegate mediaPickerControllerReferenceSizeForCustomHeaderView:picker];
+    }
+
+    return CGSizeZero;
+}
+
+- (void)mediaPickerController:(WPMediaPickerViewController *)picker configureCustomHeaderView:(UICollectionReusableView *)headerView
+{
+    if ([self.delegate respondsToSelector:@selector(mediaPickerController:configureCustomHeaderView:)]) {
+        [self.delegate mediaPickerController:picker configureCustomHeaderView:headerView];
+    }
+}
+
 - (nullable UIViewController *)mediaPickerController:(WPMediaPickerViewController *)picker previewViewControllerForAssets:(nonnull NSArray<id<WPMediaAsset>> *)assets selectedIndex:(NSInteger)selected {
     UIViewController *previewVC;
     if ([self.delegate respondsToSelector:@selector(mediaPickerController:previewViewControllerForAssets:selectedIndex:)]) {

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.0'
+  s.version       = '1.8.1-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
This PR adds support for custom header views in the media picker collection view. This will be used in WordPress-iOS to show an info panel at the top of the picker if a user has only provided limited access to their photo library.

Three methods have been added to the media picker delegate protocol:

* `mediaPickerController(_:configureCustomHeaderView:)`
* `mediaPickerControllerReferenceSizeForCustomHeaderView(_:)`
* `mediaPickerControllerShouldShowCustomHeaderView(_:)`

These in combination allow a delegate to control whether a custom header view is displayed, configure the view if necessary before it's displayed, and provide a reference size which will be used to display the view at the correct size.

In order for these to have an effect, the custom header type must be registered using a new method on `WPMediaPickerViewController`: `registerClassForCustomHeaderView(_:)`. The class must be a subclass of `UICollectionReusableView`.

I've added an option to the demo app to show an example custom header:

|    |    |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-01-11 at 22 54 00](https://user-images.githubusercontent.com/4780/149034279-52011948-2634-444f-9b32-a7a7fd377279.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-01-11 at 22 54 09](https://user-images.githubusercontent.com/4780/149034265-ae200b4a-cb4a-4eb2-b050-fb9d01ae245c.png) |

There are a few small caveats around the current implementation:

* Only one header is supported, and is displayed at the top of the collection view. Headers scroll with the collection view content.
* Because the 'capture cell' (displaying a live feed of the device's camera, allowing the user to capture an image) also uses a collection view header, it can't be used at the same time as a custom header.

### To test

* Build and run the demo app
* Tap the + button and navigate around the picker. Ensure you don't see a special header above the regular image cells. Ensure you can select an image.
* Dismiss the picker and tap Options in the top left. Toggle the Show Custom Header option at the bottom.
* Dismiss the options screen and tap + to show the picker again. Navigate into an album and ensure you see the demo header at the top.
* The demo header should have a green background, which is being overridden by the `configureCustomHeaderView` delegate method (the demo header class has a red background on initialization).