### PR TITLE
Invalidate custom header layout if trait collection changes

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -294,6 +294,18 @@ static CGFloat SelectAnimationTime = 0.2;
     [self unregisterForKeyboardNotifications];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    if ([self shouldShowCustomHeaderView]) {
+        // If there's a custom header, we'll invalidate it so that it can adapt itself to dynamic type changes.
+        UICollectionViewFlowLayoutInvalidationContext *context  = [UICollectionViewFlowLayoutInvalidationContext new];
+        [context invalidateSupplementaryElementsOfKind:UICollectionElementKindSectionHeader atIndexPaths:@[ [NSIndexPath indexPathForRow:0 inSection:0] ]];
+        [self.collectionView.collectionViewLayout invalidateLayout];
+    }
+}
+
 - (UIViewController *)viewControllerToUseToPresent
 {
     // viewControllerToUseToPresent defaults to self but could be set to nil. Reset to self if needed.

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.2-beta.1'
+  s.version       = '1.8.2-beta.2'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
This PR invalides the layout for a custom header (if provided) in the case that the trait collection changes. This allows the custom header view to potentially resize itself to handle the trait change (for example, when the dynamic type size changes).

**To test**

Please test using the steps in the associated WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17795
