### PR TITLE
Merge 1.8.2 stable release

### DIFF
--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.2-beta.2'
+  s.version       = '1.8.2'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze process for WordPress iOS 19.1 and is here to leave a breadcrumb in the release process. I will be admin-merge it and deploy the new version as soon as CI is green. I'll submit a merge PR against `trunk` for review later on.