### PR TITLE
Fix: incorrect placement of empty view in picker

### DIFF
--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -1454,7 +1454,8 @@ referenceSizeForFooterInSection:(NSInteger)section
         } else {
             emptyViewFrame.origin.y = self.searchBarTopConstraint.constant;
         }
-
+//        emptyViewFrame.size.height -= self.view.layoutMargins.bottom;
+//        emptyViewFrame.size.height -= self.view.layoutMargins.top;
         _emptyViewController.view.frame = emptyViewFrame;
     } else {
         self.emptyView.center = self.collectionView.center;

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -1451,11 +1451,9 @@ referenceSizeForFooterInSection:(NSInteger)section
 
         if ([self.searchBar.text isEqualToString:@""]) {
             emptyViewFrame.origin.y -= self.searchBar.frame.size.height/2;
-        } else {
-            emptyViewFrame.origin.y = self.searchBarTopConstraint.constant;
         }
-//        emptyViewFrame.size.height -= self.view.layoutMargins.bottom;
-//        emptyViewFrame.size.height -= self.view.layoutMargins.top;
+        emptyViewFrame.size.height -= self.view.layoutMargins.bottom;
+        emptyViewFrame.size.height -= self.view.layoutMargins.top;
         _emptyViewController.view.frame = emptyViewFrame;
     } else {
         self.emptyView.center = self.collectionView.center;

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.3'
+  s.version       = '1.8.3-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes #386

## Description
Modifies the positioning of the empty view so that it's vertically centered and fills the whole view.

No Media | No Search Results
-|-
![media](https://user-images.githubusercontent.com/25306722/165680520-461cbd2b-43ba-4099-9f28-5bdbef1d0b8b.png)|![results](https://user-images.githubusercontent.com/25306722/165680539-d34b4e0a-81b9-474a-8e51-c03015e7412a.png)


## Testing instructions
This can be tested using https://github.com/wordpress-mobile/WordPress-iOS/pull/18471
1. Run the app
2. Switch to a site that has no media uploaded
3. Open Media
4. Make sure that the custom empty view is displayed correctly
5. Upload an image
6. Type in anything in the search bar till no results match
7. Make sure that the no results label is displayed correctly
