### PR TITLE
Fix: position of empty view to avoid message disappearing when keyboard shows up

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#2.8.0
+  - &bash_cache automattic/bash-cache#2.9.0
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-14

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,3 +2,6 @@ Fixes #
 
 To test:
 
+---
+
+- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,245 +1,49 @@
-# Change Log
-All notable changes to this project will be documented in this file.
-`WPMediaPicker` adheres to [Semantic Versioning](http://semver.org/).
+# Changelog
 
----
-## [1.8.5](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.5)
-### Changes
-- Fix issue where incorrect thumbnails are displayed during incremental updates.
+The format of this document is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
----
-## [1.8.1](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.1)
-Released on 2022-01-10. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.8.1).
+<!-- This is a comment, you won't see it when GitHub renders the Markdown file.
 
-### Changes
-- Fix crashing error when trying to access the Media Library for the first time. #375
+When releasing a new version:
 
----
-## [1.8.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.0)
-Released on 2021-10-22. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.8.0).
+1. Remove any empty section (those with `_None._`)
+2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/<version_number>)`
+3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
 
-### Changes
-- Update minimum version of supported iOS to be iOS 13.0
+## Unreleased
 
----
-## [1.7.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.7.0)
-Released on 2019-10-18. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.7.0).
+### Breaking Changes
 
-### Changes
-- Fix image/photo capture when it's done with the device rotated. #337 #338
+_None._
 
----
-## [1.6.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.6.0)
-Released on 2019-10-18. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.6.0).
+### New Features
 
-### Fixed
-- Fix bug where VC present after selection was being changed by selection updates. #353
+_None._
 
----
-## [1.5.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.5.0)
-Released on 2019-09-09. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.5.0).
+### Bug Fixes
 
-### Changes
-- Update code to have as minimum working version iOS 11.
+_None._
 
----
-## [1.4.2](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.4.2)
-Released on 2019-06-14. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.4.2).
+### Internal Changes
 
-### Fixed
-- Sorting of user albums alphabetically. #329
-- Fix selection frame when rotating device. #332
-- Fix asset display on device. #333
+_None._
 
----
-## [1.4](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.4.0)
-Released on 2019-05-01. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.4.0).
+-->
 
-### Fixed
-- Add new method to WPMediaCollectionDataSource protocol to allow for checking changes on the groups of the data source. This allow improving refresh on the WPMediaGroupViewController so that it only refresh when the group changes instead of when the assets of a group change. #322 #323
+## Unreleased
 
----
-## [1.3.4](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.3.4)
-Released on 2019-04-24. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.3.4).
+### Breaking Changes
 
-### Fixed
-- If no details of the changes are made available on PHDataSource send a change notification with the proper variable state set. Make sure observers are removed and readded when datasource changes. #305 #321
+_None._
 
----
-## [1.3](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.3)
-Released on 2018-06-21. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.3).
+### New Features
 
-### Fixed
-- Check for nil for empty View Controller. #304 
+_None._
 
----
-## [1.2](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.2)
-Released on 2018-06-21. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.2).
+### Bug Fixes
 
-### Added
-- Added the possibility to use a View Controller for the empty state. #303
+_None._
 
+### Internal Changes
 
----
-## [1.1](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.1)
-Released on 2018-06-21. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.1).
-  
-### Added
-- Added the possibility to configure a badge on the top left of the media cells. Good to display extra info about the media object. #295 #296 #299
-- It's now possible to configure the display of the each media on the carrousel view. #300
-
----
-## [1.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.0)
-Released on 2018-05-09. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.0).
-
-### Fixed
-- Fix crash when updating collection view from partial changes. #293
-
----
-## [0.28](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.28)
-Released on 2018-04-30. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.28).
-
-### Added
-
-- Implements a carousel view to preview multiple selection of assets. #281
-- Bottom action bar. #282
-
-### Fixed
-- Fix crash when dealloc WPMediaGroupCell. #280
-- Enable bounce correctly depending of scrolling type. #288
-
----
-## [0.27](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.27)
-Released on 2018-02-26. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.27).
-
-### Fixed
-- Ordering of selection highlight and position indicator. #278
-
----
-## [0.26](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.26)
-Released on 2010-01-10. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.26).
-
-### Added
-- Smart Invert support. #272
-
-### Fixed
-- Fix video player on iPhone X. #273
-- Center empty view. #274
-
----
-## [0.25](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.25)
-Released on 2017-11-20. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.25).
-
-### Added
-- Added the possibility to display a overlay view on top of the media cells. #259 #261
-- Added the possibility to search for assets on the picker. #257 #260 #268
-
-### Fixed
-- Improved reload of cells by reconfiguring the cell instead of reloading it. #269
-
----
-## [0.24](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.24)
-Released on 2017-11-01. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.24).
-
-### Fixed
-- Empty albums are filtered out of the album list. #230
-- Fix crash on reload when using the same data source. #253
-- Fixed display of count and thumbnail of albums when scrolling super quick. #255
-
-## [0.23](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.23)
-Released on 2017-10-04. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.23).
-
-### Fixed
-- Fixed layout issues for the iPhoneX. #242
-- Updated collection cell design for audio & doc files. #245
-- Fixed issues with play/pause of videos. #249
-- Pushed the minimum version of iOS to be the 10. Solved deprecation warnings. #248
-
-## [0.22](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.22)
-Released on 2017-09-21. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.22).
-
-### Fixed
-- Fixed crash on photos permission check. #239
-
-## [0.21](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.21)
-Released on 2017-09-06. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.21).
-
-### Fixed
-- Fixed some crashes and bugs on the demo app. #219 #221
-- Fixed bugs related to selection of assets and refresh. #225 #223
-- Improved performance when capturing new media inside the picker. #211
-- Photos captured using the picker were not saving metadata. #226
-
-## [0.20](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.20)
-Released on 2017-08-25. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.20).
-
-### Added
-- New design for the picker media cells. #203 #205
-- New design and interaction for album selector. #207
-
-### Fixed
-- Improved performance of loading albums and assets on the picker. #209
-- Fixed selection bug when capturing new cell. #214
-- Improved performance when capturing new media inside the picker. #211
-
-## [0.19](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.19)
-Released on 2017-07-26. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.19).
-
-#### Fixed
-- Fixed some retain cycles that were causing issues with double notifications.
-- Refactor options on the picker to allow better refresh of picker.
-- Allow selected assets to be pre-selected on the picker.
-
-## [0.18](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.18)
-Released on 2017-06-16. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.18).
-
-#### Fixed
-- Fixed unit tests compilation and started running them on Travis CI
-- Improved startup time of the picker
-- Fix long  standing issue when certain updates when switching groups where crashing the picker.
-
-## [0.17](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.17)
-Released on 2017-05-26. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.17).
-
-#### Added
-- Two new `WPMediaPickerViewControllerDelegate` methods: `mediaPickerControllerWillBeginLoadingData` and `mediaPickerControllerDidEndLoadingData` to inform the delegate when loading of data from the data source has begun / ended.
-
-## [0.16](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.16)
-Released on 2017-05-04. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.16).
-
-#### Added
-- A title to the default asset preview view controller, showing the date of the asset.
-- The media picker can now handle non-image and non-video assets, such as PDFs. The cells in the picker will show a placeholder icon, the file type, and filename.
-- The media picker will show a placeholder icon if an image or video fails to load.
-
-### Fixed
-- Video is now captured in high quality.
-- The picker's layout is now improved on iPad, for more consistent cell spacing.
-- The group picker should now be much faster to load and scroll for PHAssetCollections.
-- Date / time formatting code has been refactored / cleaned up a little, and should now better handle different locales.
-- Optimized the loading and caching of group thumbnails.
-
----
-
-## [0.15](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.15)
-Released on 2017-03-29. All issues associated with this milestone can be found using this
-[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/issues?utf8=✓&q=milestone%3A0.15).
-
-#### Added
-- A new toolbar to WPVideoPlayerView to allow control of play/pause of video assets.
-
-### Fixed
-- Fixed scrolling issues when opening the picker.
-
----
+_None._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,247 @@ _None._
 ### Internal Changes
 
 - Add this changelog file [#396]
+
+_Versions below this precede the Keep a Changelog-inspired formatting._
+
+---
+## [1.8.5](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.5)
+### Changes
+- Fix issue where incorrect thumbnails are displayed during incremental updates.
+
+---
+## [1.8.1](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.1)
+Released on 2022-01-10. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.8.1).
+
+### Changes
+- Fix crashing error when trying to access the Media Library for the first time. #375
+
+---
+## [1.8.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.0)
+Released on 2021-10-22. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.8.0).
+
+### Changes
+- Update minimum version of supported iOS to be iOS 13.0
+
+---
+## [1.7.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.7.0)
+Released on 2019-10-18. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.7.0).
+
+### Changes
+- Fix image/photo capture when it's done with the device rotated. #337 #338
+
+---
+## [1.6.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.6.0)
+Released on 2019-10-18. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.6.0).
+
+### Fixed
+- Fix bug where VC present after selection was being changed by selection updates. #353
+
+---
+## [1.5.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.5.0)
+Released on 2019-09-09. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.5.0).
+
+### Changes
+- Update code to have as minimum working version iOS 11.
+
+---
+## [1.4.2](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.4.2)
+Released on 2019-06-14. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.4.2).
+
+### Fixed
+- Sorting of user albums alphabetically. #329
+- Fix selection frame when rotating device. #332
+- Fix asset display on device. #333
+
+---
+## [1.4](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.4.0)
+Released on 2019-05-01. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.4.0).
+
+### Fixed
+- Add new method to WPMediaCollectionDataSource protocol to allow for checking changes on the groups of the data source. This allow improving refresh on the WPMediaGroupViewController so that it only refresh when the group changes instead of when the assets of a group change. #322 #323
+
+---
+## [1.3.4](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.3.4)
+Released on 2019-04-24. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.3.4).
+
+### Fixed
+- If no details of the changes are made available on PHDataSource send a change notification with the proper variable state set. Make sure observers are removed and readded when datasource changes. #305 #321
+
+---
+## [1.3](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.3)
+Released on 2018-06-21. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.3).
+
+### Fixed
+- Check for nil for empty View Controller. #304
+
+---
+## [1.2](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.2)
+Released on 2018-06-21. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.2).
+
+### Added
+- Added the possibility to use a View Controller for the empty state. #303
+
+
+---
+## [1.1](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.1)
+Released on 2018-06-21. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.1).
+
+### Added
+- Added the possibility to configure a badge on the top left of the media cells. Good to display extra info about the media object. #295 #296 #299
+- It's now possible to configure the display of the each media on the carrousel view. #300
+
+---
+## [1.0](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.0)
+Released on 2018-05-09. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A1.0).
+
+### Fixed
+- Fix crash when updating collection view from partial changes. #293
+
+---
+## [0.28](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.28)
+Released on 2018-04-30. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.28).
+
+### Added
+
+- Implements a carousel view to preview multiple selection of assets. #281
+- Bottom action bar. #282
+
+### Fixed
+- Fix crash when dealloc WPMediaGroupCell. #280
+- Enable bounce correctly depending of scrolling type. #288
+
+---
+## [0.27](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.27)
+Released on 2018-02-26. All issues associated with this milestone can be found using this [filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.27).
+
+### Fixed
+- Ordering of selection highlight and position indicator. #278
+
+---
+## [0.26](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.26)
+Released on 2010-01-10. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.26).
+
+### Added
+- Smart Invert support. #272
+
+### Fixed
+- Fix video player on iPhone X. #273
+- Center empty view. #274
+
+---
+## [0.25](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.25)
+Released on 2017-11-20. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.25).
+
+### Added
+- Added the possibility to display a overlay view on top of the media cells. #259 #261
+- Added the possibility to search for assets on the picker. #257 #260 #268
+
+### Fixed
+- Improved reload of cells by reconfiguring the cell instead of reloading it. #269
+
+---
+## [0.24](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.24)
+Released on 2017-11-01. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.24).
+
+### Fixed
+- Empty albums are filtered out of the album list. #230
+- Fix crash on reload when using the same data source. #253
+- Fixed display of count and thumbnail of albums when scrolling super quick. #255
+
+## [0.23](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.23)
+Released on 2017-10-04. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.23).
+
+### Fixed
+- Fixed layout issues for the iPhoneX. #242
+- Updated collection cell design for audio & doc files. #245
+- Fixed issues with play/pause of videos. #249
+- Pushed the minimum version of iOS to be the 10. Solved deprecation warnings. #248
+
+## [0.22](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.22)
+Released on 2017-09-21. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.22).
+
+### Fixed
+- Fixed crash on photos permission check. #239
+
+## [0.21](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.21)
+Released on 2017-09-06. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.21).
+
+### Fixed
+- Fixed some crashes and bugs on the demo app. #219 #221
+- Fixed bugs related to selection of assets and refresh. #225 #223
+- Improved performance when capturing new media inside the picker. #211
+- Photos captured using the picker were not saving metadata. #226
+
+## [0.20](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.20)
+Released on 2017-08-25. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.20).
+
+### Added
+- New design for the picker media cells. #203 #205
+- New design and interaction for album selector. #207
+
+### Fixed
+- Improved performance of loading albums and assets on the picker. #209
+- Fixed selection bug when capturing new cell. #214
+- Improved performance when capturing new media inside the picker. #211
+
+## [0.19](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.19)
+Released on 2017-07-26. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.19).
+
+#### Fixed
+- Fixed some retain cycles that were causing issues with double notifications.
+- Refactor options on the picker to allow better refresh of picker.
+- Allow selected assets to be pre-selected on the picker.
+
+## [0.18](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.18)
+Released on 2017-06-16. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.18).
+
+#### Fixed
+- Fixed unit tests compilation and started running them on Travis CI
+- Improved startup time of the picker
+- Fix long  standing issue when certain updates when switching groups where crashing the picker.
+
+## [0.17](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.17)
+Released on 2017-05-26. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.17).
+
+#### Added
+- Two new `WPMediaPickerViewControllerDelegate` methods: `mediaPickerControllerWillBeginLoadingData` and `mediaPickerControllerDidEndLoadingData` to inform the delegate when loading of data from the data source has begun / ended.
+
+## [0.16](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.16)
+Released on 2017-05-04. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/pulls?utf8=✓&q=is%3Apr%20is%3Aclosed%20milestone%3A0.16).
+
+#### Added
+- A title to the default asset preview view controller, showing the date of the asset.
+- The media picker can now handle non-image and non-video assets, such as PDFs. The cells in the picker will show a placeholder icon, the file type, and filename.
+- The media picker will show a placeholder icon if an image or video fails to load.
+
+### Fixed
+- Video is now captured in high quality.
+- The picker's layout is now improved on iPad, for more consistent cell spacing.
+- The group picker should now be much faster to load and scroll for PHAssetCollections.
+- Date / time formatting code has been refactored / cleaned up a little, and should now better handle different locales.
+- Optimized the loading and caching of group thumbnails.
+
+---
+
+## [0.15](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.15)
+Released on 2017-03-29. All issues associated with this milestone can be found using this
+[filter](https://github.com/wordpress-mobile/MediaPicker-iOS/issues?utf8=✓&q=milestone%3A0.15).
+
+#### Added
+- A new toolbar to WPVideoPlayerView to allow control of play/pause of video assets.
+
+### Fixed
+- Fixed scrolling issues when opening the picker.
+
+---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,4 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Add this changelog file [#396]

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.5'
+  s.version       = '1.8.6'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes [#18840](https://github.com/wordpress-mobile/WordPress-iOS/issues/18840), [#19514](https://github.com/wordpress-mobile/WordPress-iOS/issues/19514) 

## Description

- Changing the `emptyViewController` to manipulate your size and position using **constraints** to the View, instead of using frame manipulation.
- Changing the bottom constraint of the `emptyViewController` to follow the **Keyboard height** when the same appears.

### Before changes

https://user-images.githubusercontent.com/20734091/197835979-4dbc38c4-3cc8-4ac3-8c08-69f6f1b60c03.mp4

### After changes

| Blog Post - With Images | Blog Post - Without Images | Media - With Images | Media - Without Images |
| ------------------------ | ------------------------ | ------------------------ | ------------------------|
| ![Blog-WithImages](https://user-images.githubusercontent.com/20734091/197840197-32faae26-138c-4b9e-8a96-20c6089dfe00.gif) | ![Blog-WithoutImages](https://user-images.githubusercontent.com/20734091/197840333-a5f04e65-6316-45e2-90b2-dcc829d2a110.gif) | ![Media-WithImages](https://user-images.githubusercontent.com/20734091/197840424-c75ffca8-7cd5-4ef2-abeb-a0dbd20101f8.gif) | ![Media-WithoutImages](https://user-images.githubusercontent.com/20734091/197840567-f510082a-9f9a-44a3-8e84-0fb779f7cc58.gif) |

-----
| Gray space before | Gray space after |
| ------------------- | ------------------- |
| <img width="300" alt="" src="https://user-images.githubusercontent.com/20734091/197841053-ef31ea84-355b-47a2-a7b0-2006cd81aed2.png"> | <img width="300" alt="" src="https://user-images.githubusercontent.com/20734091/197841098-c6897350-1262-4f05-a5a8-11a8e4b85bba.png"> |

## Testing instructions

This can be tested by cloning my fork(and branch) and changing the `WordPress-iOS` Podfile to use the Pod locally:
```
pod 'WPMediaPicker', :path => '...'
```

1. Run the app
2. Switch to a site that has no media uploaded
3. Open Blog Post and add an `IMAGE` block
4. Make sure that the custom empty view is displayed correctly
5. Opens the Keyboard
6. Make sure that the message `No media matching your search` is displayed correctly
