### PR TITLE
Fix a crash during incremental update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ _Versions below this precede the Keep a Changelog-inspired formatting._
 
 ### Bug Fixes
 
-- Fix an crash that happens during an incremental update to a large media library.
+- Fix a crash that happens during an incremental update to a large media library. [#398]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,19 @@ _None._
 
 ### Internal Changes
 
-- Add this changelog file [#396]
+_None._
 
 _Versions below this precede the Keep a Changelog-inspired formatting._
+
+## [1.8.6](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.6)
+
+### Bug Fixes
+
+- Fix an crash that happens during an incremental update to a large media library.
+
+### Internal Changes
+
+- Add this changelog file [#396]
 
 ---
 ## [1.8.5](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.5)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.5)
+  - WPMediaPicker (1.8.6)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 5a74a91e11c1047e942a65de0193f93432fc2c6d
+  WPMediaPicker: 749ebfa75fb2b6df4f5e5d9d0847e9512ad74d28
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -688,9 +688,6 @@ static CGFloat SelectAnimationTime = 0.2;
         if ([inserted count] > 0) {
             [self.collectionView insertItemsAtIndexPaths:[self indexPathsFromIndexSet:inserted section:0]];
         }
-        if ([changed count] > 0) {
-            [self.collectionView reloadItemsAtIndexPaths:[self indexPathsFromIndexSet:changed section:0]];
-        }
         for (id<WPMediaMove> move in moves) {
             [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:[move from] inSection:0]
                                          toIndexPath:[NSIndexPath indexPathForItem:[move to] inSection:0]];
@@ -700,7 +697,9 @@ static CGFloat SelectAnimationTime = 0.2;
         }
     } completion:^(BOOL finished) {
         [weakSelf refreshSelection];
-        [weakSelf.collectionView reloadItemsAtIndexPaths:weakSelf.collectionView.indexPathsForSelectedItems];
+        NSMutableSet<NSIndexPath *> *indexPaths = [NSMutableSet setWithArray:[weakSelf indexPathsFromIndexSet:changed section:0]];
+        [indexPaths addObjectsFromArray:weakSelf.collectionView.indexPathsForSelectedItems];
+        [weakSelf.collectionView reloadItemsAtIndexPaths:[indexPaths allObjects]];
     }];
 
 }

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -696,7 +696,12 @@ static CGFloat SelectAnimationTime = 0.2;
             }
         }
     } completion:^(BOOL finished) {
+        if (weakSelf == nil) {
+            return;
+        }
         [weakSelf refreshSelection];
+        // Reloading the changed items here rather than in the batch update block above to fix this issue:
+        // https://github.com/wordpress-mobile/WordPress-iOS/issues/19505
         NSMutableSet<NSIndexPath *> *indexPaths = [NSMutableSet setWithArray:[weakSelf indexPathsFromIndexSet:changed section:0]];
         [indexPaths addObjectsFromArray:weakSelf.collectionView.indexPathsForSelectedItems];
         [weakSelf.collectionView reloadItemsAtIndexPaths:[indexPaths allObjects]];

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.5'
+  s.version       = '1.8.6'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
## Issue
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/19505.

I can easily reproduce this issue on current trunk branch of WordPress iOS repo, by using a site that has 36 photos in its media library and tapping the Media row in the My Site tab.

## Changes

This PR reverts a commit in [this PR](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/394/commits/eafcbd76549421bcb9dbd53ffd5c6c5641b23259) whose changes were released in v1.8.5. I've verified this change fixed the crash. But I don't know why the reverted commit would cause a crash. Reloading inside the batch update block seems to be okay according to [this API doc](https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates)

> Animates multiple insert, delete, reload, and move operations as a group.

## Test instructions

1. Prepare or choose a site that has 40 photos in its media library.
1. Checkout WordPress-iOS trunk branch and pin [the MediaPicker library dependency in the Podfile](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/Podfile#L220) to this PR branch.
1. Build and run the app.
1. Go to the site prepared in step 1.
1. Repeat the steps in https://github.com/wordpress-mobile/WordPress-iOS/issues/19505: go to "Media" screen and wait for a few seconds.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
