### PR TITLE
Fix position of empty view to avoid message disappearing when keyboard shows up

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.6)
+  - WPMediaPicker (1.8.7-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 749ebfa75fb2b6df4f5e5d9d0847e9512ad74d28
+  WPMediaPicker: 59135aebb058a95a507045f93e478516729e5c0f
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -222,6 +222,9 @@
  *  @return An empty view to display or `nil` to not display any.
  *
  *  If this method is not implemented, a default UILabel will be displayed.
+ *
+ *  In case of (emptyViewControllerForMediaPickerController) and (emptyViewForMediaPickerController) are both implemented by a parent ViewController,
+ *  the first one has precedence over the second one to be presented to the user.
  */
 - (nullable UIView *)emptyViewForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 
@@ -235,6 +238,9 @@
  *
  *  If this method is not implemented, a default ViewController with a default
  *  UILabel will be displayed.
+ *
+ *  In case of (emptyViewControllerForMediaPickerController) and (emptyViewForMediaPickerController) are both implemented by a parent ViewController,
+ *  the first one has precedence over the second one to be presented to the user.
  */
 - (nullable UIViewController *)emptyViewControllerForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 

--- a/Pod/Classes/WPMediaPickerViewController.h
+++ b/Pod/Classes/WPMediaPickerViewController.h
@@ -223,8 +223,7 @@
  *
  *  If this method is not implemented, a default UILabel will be displayed.
  *
- *  In case of (emptyViewControllerForMediaPickerController) and (emptyViewForMediaPickerController) are both implemented by a parent ViewController,
- *  the first one has precedence over the second one to be presented to the user.
+ * `emptyViewControllerForMediaPickerController` takes precedence over this method.
  */
 - (nullable UIView *)emptyViewForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 
@@ -239,8 +238,7 @@
  *  If this method is not implemented, a default ViewController with a default
  *  UILabel will be displayed.
  *
- *  In case of (emptyViewControllerForMediaPickerController) and (emptyViewForMediaPickerController) are both implemented by a parent ViewController,
- *  the first one has precedence over the second one to be presented to the user.
+ *  This method takes precedence over `emptyViewForMediaPickerController`.
  */
 - (nullable UIViewController *)emptyViewControllerForMediaPickerController:(nonnull WPMediaPickerViewController *)picker;
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -46,6 +46,7 @@ static NSString *const CustomHeaderReuseIdentifier = @"CustomHeaderReuseIdentifi
 
 @property (nonatomic, strong, readwrite) UISearchBar *searchBar;
 @property (nonatomic, strong) NSLayoutConstraint *searchBarTopConstraint;
+@property (nonatomic, assign) CGFloat currentKeyboardHeight;
 
 @property (nonatomic, strong) UIView *emptyView;
 @property (nonatomic, strong) UILabel *defaultEmptyView;
@@ -637,6 +638,7 @@ static CGFloat SelectAnimationTime = 0.2;
     [self.collectionView addSubview:self.emptyViewController.view];
 
     self.emptyViewBottomConstraint = [self.emptyViewController.view.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor];
+    [self.emptyViewBottomConstraint setConstant:-self.currentKeyboardHeight];
 
     [NSLayoutConstraint activateConstraints:
      @[
@@ -1441,7 +1443,8 @@ referenceSizeForFooterInSection:(NSInteger)section
     }
     self.collectionView.contentInset = contentInset;
     self.collectionView.scrollIndicatorInsets = contentInset;
-    [self.emptyViewBottomConstraint setConstant:-keyboardFrameEnd.size.height];
+    self.currentKeyboardHeight = keyboardFrameEnd.size.height;
+    [self.emptyViewBottomConstraint setConstant:-self.currentKeyboardHeight];
 
     [UIView animateWithDuration:0.2 animations:^{
         [self centerEmptyView];
@@ -1455,7 +1458,8 @@ referenceSizeForFooterInSection:(NSInteger)section
     contentInset.bottom = 0.f;
     self.collectionView.contentInset = contentInset;
     self.collectionView.scrollIndicatorInsets = contentInset;
-    [self.emptyViewBottomConstraint setConstant:0.f];
+    self.currentKeyboardHeight = 0.f;
+    [self.emptyViewBottomConstraint setConstant:self.currentKeyboardHeight];
 
     [UIView animateWithDuration:0.2 animations:^{
         [self centerEmptyView];

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -593,6 +593,7 @@ static CGFloat SelectAnimationTime = 0.2;
 - (void)addContainerEmptyView
 {
     if (self.emptyViewContainer != nil && self.emptyViewContainer.superview != nil) {
+        self.emptyViewContainer.hidden = false;
         [self addEmptyViewToContainer];
         return;
     }
@@ -692,29 +693,6 @@ static CGFloat SelectAnimationTime = 0.2;
      ];
 
     [self.emptyViewController didMoveToParentViewController:self];
-}
-
-- (void)removeContainerEmptyView
-{
-    [self removeEmptyViewControllerFromView];
-    [self removeEmptyView];
-    [_emptyViewContainer removeFromSuperview];
-}
-
-- (void)removeEmptyView
-{
-    if(_emptyView) {
-        [_emptyView removeFromSuperview];
-    }
-}
-
-- (void)removeEmptyViewControllerFromView
-{
-    if (_emptyViewController) {
-        [_emptyViewController willMoveToParentViewController:nil];
-        [_emptyViewController.view removeFromSuperview];
-        [_emptyViewController removeFromParentViewController];
-    }
 }
 
 - (UIViewController *)emptyViewController
@@ -945,7 +923,7 @@ static CGFloat SelectAnimationTime = 0.2;
 - (void)toggleEmptyViewFor:(NSInteger)numberOfAssets
 {
     if (numberOfAssets > 0) {
-        [self removeContainerEmptyView];
+        self.emptyViewContainer.hidden = true;
     } else {
         [self addContainerEmptyView];
     }

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -104,8 +104,8 @@ static CGFloat SelectAnimationTime = 0.2;
     [self addCollectionViewToView];
     [self setupCollectionView];
     [self setupSearchBar];
-
     [self setupLayout];
+    [self addEmptyViewContainer];
 
     //setup data
     [self.dataSource setMediaTypeFilter:self.options.filter];
@@ -590,14 +590,8 @@ static CGFloat SelectAnimationTime = 0.2;
 
 /** An empty view container to hold the emptyViewController or emptyView that comes from the delegate
  */
-- (void)addContainerEmptyView
+- (void)addEmptyViewContainer
 {
-    if (self.emptyViewContainer != nil && self.emptyViewContainer.superview != nil) {
-        self.emptyViewContainer.hidden = false;
-        [self addEmptyViewToContainer];
-        return;
-    }
-
     self.emptyViewContainer = [[UIView alloc] initWithFrame:self.collectionView.frame];
     [self.emptyViewContainer setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self.collectionView addSubview:self.emptyViewContainer];
@@ -613,8 +607,6 @@ static CGFloat SelectAnimationTime = 0.2;
        [self.emptyViewContainer.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
        ]
      ];
-    
-    [self addEmptyViewToContainer];
 }
 
 - (UIView *)emptyView
@@ -634,12 +626,12 @@ static CGFloat SelectAnimationTime = 0.2;
 
 /** Checks if the parentViewController is providing a custom empty ViewController to be added, if not, add a provided custom emptyView
  */
-- (void)addEmptyViewToContainer
+- (void)populateEmptyViewContainer
 {
     if ([self usingEmptyViewController]) {
-        [self addEmptyViewControllerToView];
+        [self addEmptyViewControllerToContainer];
     } else {
-        [self addEmptyViewToView];
+        [self addEmptyViewToContainer];
     }
 }
 
@@ -654,7 +646,7 @@ static CGFloat SelectAnimationTime = 0.2;
     return _defaultEmptyView;
 }
 
-- (void)addEmptyViewToView
+- (void)addEmptyViewToContainer
 {
     if (self.emptyView != nil && self.emptyView.superview != nil) {
         return;
@@ -673,7 +665,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
 #pragma mark - Empty View Controller support
 
-- (void)addEmptyViewControllerToView
+- (void)addEmptyViewControllerToContainer
 {
     if (self.emptyViewController != nil && self.emptyViewController.view.superview != nil) {
         return;
@@ -923,12 +915,12 @@ static CGFloat SelectAnimationTime = 0.2;
 - (void)toggleEmptyViewFor:(NSInteger)numberOfAssets
 {
     if (numberOfAssets > 0) {
-        self.emptyViewContainer.hidden = true;
+        [self.emptyViewContainer setHidden: YES];
     } else {
-        [self addContainerEmptyView];
+        [self.emptyViewContainer setHidden: NO];
+        [self populateEmptyViewContainer];
     }
 }
-
 
 - (id<WPMediaAsset>)assetForPosition:(NSIndexPath *)indexPath
 {

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -49,7 +49,7 @@ static NSString *const CustomHeaderReuseIdentifier = @"CustomHeaderReuseIdentifi
 @property (nonatomic, assign) CGFloat currentKeyboardHeight;
 
 @property (nonatomic, strong) UIView *emptyView;
-@property (nonatomic, strong) UIView *containerEmptyView;
+@property (nonatomic, strong) UIView *emptyViewContainer;
 @property (nonatomic, strong) UILabel *defaultEmptyView;
 @property (nonatomic, strong) UIViewController *emptyViewController;
 @property (nonatomic, strong) UIViewController *defaultEmptyViewController;
@@ -233,7 +233,7 @@ static CGFloat SelectAnimationTime = 0.2;
     layout.minimumInteritemSpacing = photoSpacing;
 
     [self resetContentInset];
-    [self adjustEmptyView];
+    [self.view layoutIfNeeded];
 }
 
 - (void)resetContentInset
@@ -592,28 +592,28 @@ static CGFloat SelectAnimationTime = 0.2;
  */
 - (void)addContainerEmptyView
 {
-    if (self.containerEmptyView != nil && self.containerEmptyView.superview != nil) {
-        [self selectEmptyView];
+    if (self.emptyViewContainer != nil && self.emptyViewContainer.superview != nil) {
+        [self addEmptyViewToContainer];
         return;
     }
 
-    self.containerEmptyView = [[UIView alloc] initWithFrame:self.collectionView.frame];
-    [self.containerEmptyView setTranslatesAutoresizingMaskIntoConstraints:NO];
-    [self.collectionView addSubview:self.containerEmptyView];
+    self.emptyViewContainer = [[UIView alloc] initWithFrame:self.collectionView.frame];
+    [self.emptyViewContainer setTranslatesAutoresizingMaskIntoConstraints:NO];
+    [self.collectionView addSubview:self.emptyViewContainer];
     
-    self.emptyViewBottomConstraint = [self.containerEmptyView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor];
+    self.emptyViewBottomConstraint = [self.emptyViewContainer.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor];
     [self.emptyViewBottomConstraint setConstant:-self.currentKeyboardHeight];
 
     [NSLayoutConstraint activateConstraints:
      @[
-       [self.containerEmptyView.topAnchor constraintEqualToAnchor:self.collectionView.topAnchor],
+       [self.emptyViewContainer.topAnchor constraintEqualToAnchor:self.collectionView.topAnchor],
        self.emptyViewBottomConstraint,
-       [self.containerEmptyView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
-       [self.containerEmptyView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
+       [self.emptyViewContainer.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+       [self.emptyViewContainer.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
        ]
      ];
     
-    [self selectEmptyView];
+    [self addEmptyViewToContainer];
 }
 
 - (UIView *)emptyView
@@ -633,7 +633,7 @@ static CGFloat SelectAnimationTime = 0.2;
 
 /** Checks if the parentViewController is providing a custom empty ViewController to be added, if not, add a provided custom emptyView
  */
-- (void)selectEmptyView
+- (void)addEmptyViewToContainer
 {
     if ([self usingEmptyViewController]) {
         [self addEmptyViewControllerToView];
@@ -660,12 +660,12 @@ static CGFloat SelectAnimationTime = 0.2;
     }
 
     [self.emptyView setTranslatesAutoresizingMaskIntoConstraints:NO];
-    [self.containerEmptyView addSubview:self.emptyView];
+    [self.emptyViewContainer addSubview:self.emptyView];
     
     [NSLayoutConstraint activateConstraints:
      @[
-       [self.emptyView.centerYAnchor constraintEqualToAnchor:self.containerEmptyView.centerYAnchor],
-       [self.emptyView.centerXAnchor constraintEqualToAnchor:self.containerEmptyView.centerXAnchor]
+       [self.emptyView.centerYAnchor constraintEqualToAnchor:self.emptyViewContainer.centerYAnchor],
+       [self.emptyView.centerXAnchor constraintEqualToAnchor:self.emptyViewContainer.centerXAnchor]
        ]
      ];
 }
@@ -680,14 +680,14 @@ static CGFloat SelectAnimationTime = 0.2;
 
     [self addChildViewController:self.emptyViewController];
     [self.emptyViewController.view setTranslatesAutoresizingMaskIntoConstraints:NO];
-    [self.containerEmptyView addSubview:self.emptyViewController.view];
+    [self.emptyViewContainer addSubview:self.emptyViewController.view];
 
     [NSLayoutConstraint activateConstraints:
      @[
-       [self.emptyViewController.view.topAnchor constraintEqualToAnchor:self.containerEmptyView.topAnchor],
-       [self.emptyViewController.view.bottomAnchor constraintEqualToAnchor:self.containerEmptyView.bottomAnchor],
-       [self.emptyViewController.view.leadingAnchor constraintEqualToAnchor:self.containerEmptyView.leadingAnchor],
-       [self.emptyViewController.view.trailingAnchor constraintEqualToAnchor:self.containerEmptyView.trailingAnchor]
+       [self.emptyViewController.view.topAnchor constraintEqualToAnchor:self.emptyViewContainer.topAnchor],
+       [self.emptyViewController.view.bottomAnchor constraintEqualToAnchor:self.emptyViewContainer.bottomAnchor],
+       [self.emptyViewController.view.leadingAnchor constraintEqualToAnchor:self.emptyViewContainer.leadingAnchor],
+       [self.emptyViewController.view.trailingAnchor constraintEqualToAnchor:self.emptyViewContainer.trailingAnchor]
        ]
      ];
 
@@ -698,7 +698,7 @@ static CGFloat SelectAnimationTime = 0.2;
 {
     [self removeEmptyViewControllerFromView];
     [self removeEmptyView];
-    [_containerEmptyView removeFromSuperview];
+    [_emptyViewContainer removeFromSuperview];
 }
 
 - (void)removeEmptyView
@@ -1508,7 +1508,7 @@ referenceSizeForFooterInSection:(NSInteger)section
     [self.emptyViewBottomConstraint setConstant:-self.currentKeyboardHeight];
 
     [UIView animateWithDuration:0.2 animations:^{
-        [self adjustEmptyView];
+        [self.view layoutIfNeeded];
         [self.collectionView.collectionViewLayout invalidateLayout];
     }];
 }
@@ -1520,20 +1520,12 @@ referenceSizeForFooterInSection:(NSInteger)section
     self.collectionView.contentInset = contentInset;
     self.collectionView.scrollIndicatorInsets = contentInset;
     self.currentKeyboardHeight = 0.f;
-    [self.emptyViewBottomConstraint setConstant:self.currentKeyboardHeight];
+    [self.emptyViewBottomConstraint setConstant:-self.currentKeyboardHeight];
 
     [UIView animateWithDuration:0.2 animations:^{
-        [self adjustEmptyView];
+        [self.view layoutIfNeeded];
         [self.collectionView.collectionViewLayout invalidateLayout];
     }];
-}
-
-/**
- Adjusts empty view to refresh constraints based on the main view.
- */
-- (void)adjustEmptyView
-{
-    [self.view layoutIfNeeded];
 }
 
 #pragma mark - WPAssetViewControllerDelegate

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -588,6 +588,8 @@ static CGFloat SelectAnimationTime = 0.2;
 
 #pragma mark - Empty View support
 
+/** An empty view container to hold the emptyViewController or emptyView that comes from the delegate
+ */
 - (void)addContainerEmptyView
 {
     if (self.containerEmptyView != nil && self.containerEmptyView.superview != nil) {
@@ -629,6 +631,8 @@ static CGFloat SelectAnimationTime = 0.2;
     return _emptyView;
 }
 
+/** Checks if the parentViewController is providing a custom empty ViewController to be added, if not, add a provided custom emptyView
+ */
 - (void)selectEmptyView
 {
     if ([self usingEmptyViewController]) {

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.5'
+  s.version       = '1.8.6'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.6-beta.1'
+  s.version       = '1.8.7-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.6'
+  s.version       = '1.8.6-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes [#18840](https://github.com/wordpress-mobile/WordPress-iOS/issues/18840), [#19514](https://github.com/wordpress-mobile/WordPress-iOS/issues/19514) 

## Description

- Changing the `emptyViewController` to manipulate your size and position using **constraints** to the View, instead of using frame manipulation.
- Changing the bottom constraint of the `emptyViewController` to follow the **Keyboard height** when the same appears.

### Issue

https://user-images.githubusercontent.com/20734091/197835979-4dbc38c4-3cc8-4ac3-8c08-69f6f1b60c03.mp4

### After changes

| Blog Post - With Images | Blog Post - Without Images | Media - With Images | Media - Without Images |
| ------------------------ | ------------------------ | ------------------------ | ------------------------|
| ![Blog-WithImages](https://user-images.githubusercontent.com/20734091/197840197-32faae26-138c-4b9e-8a96-20c6089dfe00.gif) | ![Blog-WithoutImages](https://user-images.githubusercontent.com/20734091/197840333-a5f04e65-6316-45e2-90b2-dcc829d2a110.gif) | ![Media-WithImages](https://user-images.githubusercontent.com/20734091/197840424-c75ffca8-7cd5-4ef2-abeb-a0dbd20101f8.gif) | ![Media-WithoutImages](https://user-images.githubusercontent.com/20734091/197840567-f510082a-9f9a-44a3-8e84-0fb779f7cc58.gif) |

-----
| Gray space before | Gray space after |
| ------------------- | ------------------- |
| <img width="300" alt="" src="https://user-images.githubusercontent.com/20734091/197841053-ef31ea84-355b-47a2-a7b0-2006cd81aed2.png"> | <img width="300" alt="" src="https://user-images.githubusercontent.com/20734091/197841098-c6897350-1262-4f05-a5a8-11a8e4b85bba.png"> |

## Testing instructions

This can be tested by cloning my fork(and branch) and changing the `WordPress-iOS` Podfile to use the Pod locally:
```
pod 'WPMediaPicker', :path => '...'
```

1. Run the app
2. Switch to a site that has no media uploaded
3. Open Blog Post and add an `IMAGE` block
4. Make sure that the custom empty view is displayed correctly
5. Opens the Keyboard
6. Make sure that the message `No media matching your search` is displayed correctly