### PR TITLE
Merge 1.8.7 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## [1.8.7](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.7)
+
+### Bug Fixes
+
+- Fix empty view position to avoid message disappearing when keyboard shows up. [#399]
+
 _Versions below this precede the Keep a Changelog-inspired formatting._
 
 ## [1.8.6](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.6)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.7-beta.1)
+  - WPMediaPicker (1.8.7)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 59135aebb058a95a507045f93e478516729e5c0f
+  WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.7-beta.1'
+  s.version       = '1.8.7'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 21.2 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
