### PR TITLE
Point `bash-cache` plugin to new `a8c-ci-toolkit` location

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#2.13.0
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-14

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#2.9.0
+  - &bash_cache automattic/a8c-ci-toolkit#2.13.0
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-14


### PR DESCRIPTION
While I was at it, I also updated the version to the latest, 2.13.0.

This was done via:

```
find . -type f -name "*.yml" -exec sed -i '' 's/automattic\/bash-cache#[0-9.]\{1,\}/automattic\/a8c-ci-toolkit#2.13.0/g' {} +
```

If CI is green, we're good to merge.

Internal reference: paaHJt-4z0-p2



---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
