### PR TITLE
Fix crash when displaying an empty view

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.7)
+  - WPMediaPicker (1.8.8-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
+  WPMediaPicker: 3b0d7272bec6eb0d8bc267daa5606c9b259e6cbb
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -696,7 +696,8 @@ static CGFloat SelectAnimationTime = 0.2;
     if ([self usingEmptyViewController]) {
         _emptyViewController = [self.mediaPickerDelegate emptyViewControllerForMediaPickerController:self];
     }
-    else {
+
+    if (_emptyViewController == nil) {
         _emptyViewController = self.defaultEmptyViewController;
     }
     

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.7'
+  s.version       = '1.8.8-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
## References
- [WPiOS Issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/19965)
- [WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/20666)

## Description
If the media picker delegate implements the `emptyViewController` function but ends up returning nil, this results in a crash. This PR makes sure that the empty view controller is always set, even if the delegate returns nil. 

## Testing Details
Please test using the referenced WPiOS PR.

---
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
