### PR TITLE
Merge release 1.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,13 @@ _None._
 
 _None._
 
-## [1.8.7](https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/1.8.7)
+## 1.8.8
+
+### Bug Fixes
+
+- Fix a possible crash when displaying an empty view [#409]
+
+## 1.8.7
 
 ### Bug Fixes
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.8-beta.1)
+  - WPMediaPicker (1.8.8)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 3b0d7272bec6eb0d8bc267daa5606c9b259e6cbb
+  WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.8-beta.1'
+  s.version       = '1.8.8'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for [Jetpack and WordPress iOS 22.4](https://github.com/wordpress-mobile/WordPress-iOS/milestone/246) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.