### PR TITLE
Fix crash when the same media picker instance gets pushed twice

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.8)
+  - WPMediaPicker (1.8.9-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
+  WPMediaPicker: 0ef7f4abcbff7ad20e271e7d09586e32924f5785
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/Pod/Classes/WPNavigationMediaPickerViewController.m
+++ b/Pod/Classes/WPNavigationMediaPickerViewController.m
@@ -206,7 +206,13 @@ static NSString *const ArrowDown = @"\u25be";
 {
     [self.mediaPicker setGroup:group];
     self.mediaPicker.title = group.name;
-    [self.internalNavigationController pushViewController:self.mediaPicker animated:YES];
+
+    // Defensive code to address the following crash https://github.com/wordpress-mobile/WordPress-iOS/issues/20890.
+    // There are reports of `UITableViewController/didSelectRowAt` being called
+    // twice under certain circumstances https://stackoverflow.com/questions/5687991/uitableview-didselectrowatindexpath-called-twice
+    if (self.internalNavigationController.topViewController != self.mediaPicker) {
+        [self.internalNavigationController pushViewController:self.mediaPicker animated:YES];
+    }
 }
 
 - (void)mediaGroupPickerViewControllerDidCancel:(WPMediaGroupPickerViewController *)picker

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.8'
+  s.version       = '1.8.9-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes [#20890](https://github.com/wordpress-mobile/WordPress-iOS/issues/20890) reported in WP-iOS.

I haven't found any ways to reproduce it, but this defensive code should address the crash. If the same `UIViewController` is pushes to the navigation stack twice, it does crash every time.

The changes can be tested in https://github.com/wordpress-mobile/WordPress-iOS/pull/21105

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
