### PR TITLE
Avoid `WPMediaPickerViewController` `performBatchUpdates` crash by wrapping the call in try-catch block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 1.8.9
+
+### Bug Fixes
+
+- Fix WPMediaPickerViewController crash when performing batch updates [#412]
+
 ## 1.8.8
 
 ### Bug Fixes

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.8)
+  - WPMediaPicker (1.8.9-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
+  WPMediaPicker: 0ef7f4abcbff7ad20e271e7d09586e32924f5785
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -134,7 +134,11 @@ static CGFloat SelectAnimationTime = 0.2;
                                     return;
                                 }
                                 if (incrementalChanges) {
-                                    [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
+                                    @try {
+                                        [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
+                                    } @catch (NSException *exception) {
+                                        [weakSelf.collectionView reloadData];
+                                    }
                                 } else {
                                     [weakSelf.collectionView reloadData];
                                 }

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -134,6 +134,19 @@ static CGFloat SelectAnimationTime = 0.2;
                                     return;
                                 }
                                 if (incrementalChanges) {
+                                    /// Avoid NSInternalInconsistencyException crash by wrapping performBatchUpdates in the try catch block.
+                                    ///
+                                    /// Apple documentation indicates if the collection view’s layout isn’t up to date before you call performBatchUpdates,
+                                    /// additional reload may occur that can cause problems. Developers should update the data model inside the updates
+                                    /// block or ensure the layout is updated before calling performBatchUpdates.
+                                    /// However, MediaLibraryPickerDataSource reloads the data source before view controller gets informed about updates,
+                                    /// creating a possibility for a crash.
+                                    /// https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates
+                                    ///
+                                    /// Apple engineers reiterate this fact and point out the best way to avoid this issue is to adopt
+                                    /// UICollectionViewDiffableDataSource which requires refactoring of the current solution
+                                    /// https://developer.apple.com/forums/thread/728797?answerId=751887022#751887022
+                                    
                                     @try {
                                         [weakSelf updateDataWithRemoved:removed inserted:inserted changed:changed moved:moves];
                                     } @catch (NSException *exception) {

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.8'
+  s.version       = '1.8.9-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21102

### Description

`WPMediaPickerViewController` crashes with `NSInternalInconsistencyException`. The crash is not always reproducible but [spiked significantly with 22.8 release. ](https://github.com/wordpress-mobile/WordPress-iOS/issues/21102#issuecomment-1649344483)

The rise in crashes could be related to some changes [in media-picker](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/409) and a new collection view exception in [iOS 16.4](https://developer.apple.com/forums/thread/728797?answerId=751887022#751887022).

The proposed (short-term) solution for NSInternalInconsistencyException crashes it to wrap performBatchUpdates in the try catch block.

Apple documentation indicates if the collection view’s layout isn’t up to date before you call performBatchUpdates, additional reload may occur that can cause problems. Developers should update the data model inside the updates block or ensure the layout is updated before calling performBatchUpdates. However, MediaLibraryPickerDataSource reloads the data source before view controller gets informed about updates, creating a possibility for a crash. 

: https://developer.apple.com/documentation/uikit/uicollectionview/1618045-performbatchupdates

Apple engineers reiterate this fact and point out the best way to avoid this issue is to adopt `UICollectionViewDiffableDataSource` which requires refactoring of the current solution. 

Link to Apple forum thread: https://developer.apple.com/forums/thread/728797?answerId=751887022#751887022

## To test:

The crash is only reproducible in some of the cases, we couldn't determine an environment that would make the issue reproducible consistently. 

## Before

https://github.com/wordpress-mobile/MediaPicker-iOS/assets/4062343/3aad84d2-9e3e-4caf-bc9e-d92ceb92a370

## After

https://github.com/wordpress-mobile/MediaPicker-iOS/assets/4062343/28849520-3265-42c6-922a-0e2ec176604d

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
