### PR TITLE
Release version 1.8.9 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _None._
 
 ### Bug Fixes
 
-- Fix WPMediaPickerViewController crash when performing batch updates [#412]
+- Fix `WPMediaPickerViewController` crash when performing batch updates [#412]
 
 ## 1.8.8
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.9-beta.1)
+  - WPMediaPicker (1.8.9)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 0ef7f4abcbff7ad20e271e7d09586e32924f5785
+  WPMediaPicker: 0ec0ee22f68e8cb9d83e71bdcf2e76d931ef7f91
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.9-beta.1'
+  s.version       = '1.8.9'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Merge 1.8.9 stable release

This version bump PR is part of the code freeze workflow for [WordPress iOS 23.0](https://github.com/wordpress-mobile/WordPress-iOS/issues?q=milestone%3A%2223.0%22+sort%3Aupdated-desc+) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.