### PR TITLE
Avoid WPMediaPickerViewController reloadItemsAtIndexPaths crash by wrapping the call in try-catch block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 1.8.10
+
+### Bug Fixes
+
+- Fix WPMediaPickerViewController crash when reloading collection view items [#414]
+
 ## 1.8.9
 
 ### Bug Fixes

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.9-beta.1)
+  - WPMediaPicker (1.8.10-beta.1)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 0ef7f4abcbff7ad20e271e7d09586e32924f5785
+  WPMediaPicker: d669d11c38f78597edcb338a58a0d973ae51912a
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/Pod/Classes/WPMediaPickerViewController.m
+++ b/Pod/Classes/WPMediaPickerViewController.m
@@ -773,11 +773,16 @@ static CGFloat SelectAnimationTime = 0.2;
             return;
         }
         [weakSelf refreshSelection];
-        // Reloading the changed items here rather than in the batch update block above to fix this issue:
-        // https://github.com/wordpress-mobile/WordPress-iOS/issues/19505
-        NSMutableSet<NSIndexPath *> *indexPaths = [NSMutableSet setWithArray:[weakSelf indexPathsFromIndexSet:changed section:0]];
-        [indexPaths addObjectsFromArray:weakSelf.collectionView.indexPathsForSelectedItems];
-        [weakSelf.collectionView reloadItemsAtIndexPaths:[indexPaths allObjects]];
+
+        @try {
+            // Reloading the changed items here rather than in the batch update block above to fix this issue:
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/19505
+            NSMutableSet<NSIndexPath *> *indexPaths = [NSMutableSet setWithArray:[weakSelf indexPathsFromIndexSet:changed section:0]];
+            [indexPaths addObjectsFromArray:weakSelf.collectionView.indexPathsForSelectedItems];
+            [weakSelf.collectionView reloadItemsAtIndexPaths:[indexPaths allObjects]];
+        } @catch (NSException *exception) {
+            [weakSelf.collectionView reloadData];
+        }
     }];
 
 }

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.9-beta.1'
+  s.version       = '1.8.10-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes #21102

This is an extension of https://github.com/wordpress-mobile/MediaPicker-iOS/pull/412 fix.

There're still some crashes happening in `WPMediaPickerViewController`. Although `updateDataWithRemoved` is alredy called from within try-catch block, the logic inside the completion block happens asynchronously and happens outside the scope of try-catch block`

To test:

I couldn't reproduce the original crash, however, adding a fake `insertItem..` calls in the completion block I was able to reproduce similar crashes and confirm that try-catch block helps to avoid them temporarily. 

The best way to avoid these crashes long term is to adopt UICollectionViewDiffableDataSource which requires refactoring of the current solution.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
