### PR TITLE
Allow camera use with limited library permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Allow camera use when limited photo library permission is granted [#419]
 
 ### Internal Changes
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -463,7 +463,6 @@
                 return;
             }
             case PHAuthorizationStatusDenied:
-            case PHAuthorizationStatusLimited:
             {
                 if (completionBlock) {
                     dispatch_async(dispatch_get_main_queue(), ^{
@@ -481,6 +480,7 @@
                 return;
             }
             case PHAuthorizationStatusAuthorized:
+            case PHAuthorizationStatusLimited:
             {
                 dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
                     [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.11-beta.1'
+  s.version       = '1.8.10'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.10'
+  s.version       = '1.8.11-beta.1'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes #419

## Description

Previously, any attempt to add an image from the camera when you had only granted `PHAuthorizationStatusLimited` photo library permission resulted in an error message.

The example app handled that by directing users to go to settings and change their permission… but that’s not very obvious, after all, they’re not trying to add something from their library. Apple does not require library authorization for use of the camera.

This PR changes the `limited` permission to be handled identically to `authorized`, which removes the error message.

## To test:

1. Launch the example app
2. Tap the `Tap here to quick select assets` row
3. When prompted, grant limited access to one or more photos in your library
4. When prompted, grant camera access
5. Use the camera interface to take a photo
6. Tap `Use photo` – note that you do not see an error at this point.
7. Select the photo in the collection view
8. Tap `Done`
9. Observe that it's added to the list

## Screenshots

https://github.com/wordpress-mobile/MediaPicker-iOS/assets/2472348/d8066250-ea2e-410c-9bde-dabfbe96dd88


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
