### PR TITLE
Issue/423 prevent index overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 1.8.12
+
+### Bug Fixes
+
+- Prevent crash when unexpected indexes received in a PHAsset changeset [#423]
+
 ## 1.8.11
 
 ### Bug Fixes

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WPMediaPicker (1.8.11)
+  - WPMediaPicker (1.8.12)
 
 DEPENDENCIES:
   - WPMediaPicker (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  WPMediaPicker: 79548964e9c7e131ccfa72270bdda3aec8fa56b5
+  WPMediaPicker: e9eaa804e1b0288d7969776608053ae0ea2941f2
 
 PODFILE CHECKSUM: 31590cb12765a73c9da27d6ea5b8b127c095d71d
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -360,7 +360,11 @@
     // Adjust the index so items are returned in reverse order.
     // We do this, rather than specifying the sort order in PHFetchOptions,
     // to preserve the sort order of assets in the Photos app (only in reverse).
-    return (count - 1) - index;
+    if (index < count) {
+        return (count - 1) - index;
+    } else {
+        @throw NSRangeException;
+    }
 }
 
 - (NSIndexSet *)adjustedIndexesForIndexSet:(NSIndexSet *)indexes
@@ -373,7 +377,7 @@
 {
     NSMutableIndexSet *adjustedSet = [NSMutableIndexSet new];
     [indexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
-        if (idx != NSNotFound) {
+        if (idx < count) {
             [adjustedSet addIndex:[self adjustedIndexForIndex:idx forCount: count]];
         }
     }];

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -378,7 +378,10 @@
     NSMutableIndexSet *adjustedSet = [NSMutableIndexSet new];
     [indexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
         if (idx < count) {
-            [adjustedSet addIndex:[self adjustedIndexForIndex:idx forCount: count]];
+            NSInteger adjustedIndex = [self adjustedIndexForIndex:idx forCount: count];
+            if (adjustedIndex < NSNotFound) {
+                [adjustedSet addIndex:adjustedIndex];
+            }
         }
     }];
 

--- a/Pod/Classes/WPPHAssetDataSource.m
+++ b/Pod/Classes/WPPHAssetDataSource.m
@@ -97,8 +97,9 @@
         BOOL incrementalChanges = assetsChangeDetails.hasIncrementalChanges;
         // Capture removed, changed, and moved indexes before fetching results for incremental chaanges.
         // The adjustedIndex depends on the *old* asset count.
-        NSIndexSet *removedIndexes = [self adjustedIndexesForIndexSet:assetsChangeDetails.removedIndexes];
-        NSIndexSet *changedIndexes = [self adjustedIndexesForIndexSet:assetsChangeDetails.changedIndexes];
+        NSInteger oldCount = assetsChangeDetails.fetchResultBeforeChanges.count;
+        NSIndexSet *removedIndexes = [self adjustedIndexesForIndexSet:assetsChangeDetails.removedIndexes forCount:oldCount];
+        NSIndexSet *changedIndexes = [self adjustedIndexesForIndexSet:assetsChangeDetails.changedIndexes forCount:oldCount];
         NSMutableArray *moves = [NSMutableArray array];
         if  (assetsChangeDetails.hasMoves) {
             [assetsChangeDetails enumerateMovesWithBlock:^(NSUInteger fromIndex, NSUInteger toIndex) {

--- a/WPMediaPicker.podspec
+++ b/WPMediaPicker.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WPMediaPicker'
-  s.version       = '1.8.11'
+  s.version       = '1.8.12'
 
   s.summary       = 'WPMediaPicker is an iOS controller that allows capture and picking of media assets.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes #423 

This is to resolve a crash which happened when `-[WPPHAssetDataSource photoLibraryDidChange:]` was called,with an invalid (seeming) `changedIndexes` value.

To test:

I wasn't ever able to actually reproduce the crash, but I believe it happened due to a combination of:
1. Indexes which were greater than the count, leading to:
2. Overflows to a very high UInt when doing the arithmetic in `-[WPPHAssetDataSource adjustedIndexForIndex:forCount:]`
3. Those not being properly checked before they were passed to `-[NSMutableIndexSet addIndex:]`, which requires that the UInts it's passed be between 0 and NSIntegerMax -1.

I've made a few tweaks to avoid that:
1. Throw an exception if we try to adjust an index which is greater than the count. It will lead to a negative number, which makes no sense for an index
2. Don't even attempt to adjust the index in `-[WPPHAssetDataSource adjustedIndexesForIndexSet:forCount:]` if it's greater than the count.
3. Use Apple's record of the count of assets before the changeset, not our `assetCount` which may be out of date.

I've tested it by adding to the indexes of any changes in `photoLibraryDidChange`, before passing them to the adjust functions, and checking that it doesn't crash. I tested in the Woo app.

Testing steps:
1. Launch the app using the new version of MediaPicker
2. Open a product, and add an image to it
3. Go to the camera and take some photos
4. Go to Photos and edit some of the recent photos, and delete some too
5. Go back to woo and check it doesn't crash

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
